### PR TITLE
引用投稿: 添付ファイル対応の統一とレガシー画像処理の撤去

### DIFF
--- a/resources/js/Components/FileUpload.vue
+++ b/resources/js/Components/FileUpload.vue
@@ -119,6 +119,17 @@ export default {
   },
 
   methods: {
+    // 親コンポーネントから直接ファイルを投入するための公開メソッド
+    processExternalFiles(newFiles) {
+      if (!newFiles || newFiles.length === 0) return
+      const list = Array.from(newFiles)
+      this.processFiles(list)
+    },
+
+    // 親からファイル選択ダイアログを開くための公開メソッド
+    openFileDialog() {
+      if (this.$refs.fileInput) this.$refs.fileInput.click()
+    },
     handleDrop(e) {
       e.preventDefault()
       this.isDragging = false

--- a/resources/js/Components/QuotePostForm.vue
+++ b/resources/js/Components/QuotePostForm.vue
@@ -66,6 +66,12 @@ const onTextDrop = (e) => {
     }
 };
 
+// テキストエリア外に完全にマウスが離れた場合のフェイルセーフ
+const onTextMouseLeave = () => {
+    dragDepth = 0;
+    isDragOverTextbox.value = false;
+};
+
 onMounted(() => {
     _preventIfFiles = (e) => {
         if (hasFiles(e)) {
@@ -189,6 +195,7 @@ const truncatedMessage = computed(() => {
                     @dragover="onTextDragOver"
                     @dragleave="onTextDragLeave"
                     @drop="onTextDrop"
+                    @mouseleave="onTextMouseLeave"
                 ></textarea>
                 <!-- 小さな添付ボタン（クリックで選択） -->
                 <button
@@ -243,7 +250,6 @@ const truncatedMessage = computed(() => {
                 </button>
             </div>
 
-            
         </div>
     </div>
 </template>

--- a/resources/js/Components/QuotePostForm.vue
+++ b/resources/js/Components/QuotePostForm.vue
@@ -1,8 +1,7 @@
 <script setup>
-import { ref, computed } from "vue";
+import { ref, computed, onMounted, onUnmounted } from "vue";
 import { router } from "@inertiajs/vue3";
-import { handleImageChange } from "@/Utils/imageHandler";
-import ImageModal from "./ImageModal.vue";
+import FileUpload from "./FileUpload.vue";
 
 // 引用付き投稿フォームのprops
 const props = defineProps({
@@ -18,13 +17,71 @@ const emit = defineEmits(["close"]); // フォームを閉じる
 const newPostContent = ref(""); // 投稿の内容
 const newPostTitle = ref(""); // 投稿のタイトル
 
-// 画像関連のref
-const image = ref(null); // 画像ファイル
-const imagePreview = ref(null); // 画像プレビュー
-const isModalOpen = ref(false); // モーダル表示
-const fileInput = ref(null); // ファイル選択ボタン
+// 統一ファイル添付システム
+const fileUploadRef = ref(null);
+const attachedFiles = ref([]);
+const localErrorMessage = ref(null);
 
-const localErrorMessage = ref(null); // エラーメッセージ
+// D&D UIをテキストエリア上のみ表示するための状態
+const isDragOverTextbox = ref(false);
+const textAreaRef = ref(null);
+let dragDepth = 0;
+let _preventIfFiles;
+
+const hasFiles = (e) => {
+    const types = e?.dataTransfer?.types;
+    return types && (types.includes && types.includes('Files'));
+};
+
+const onTextDragEnter = (e) => {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    dragDepth++;
+    isDragOverTextbox.value = true;
+};
+
+const onTextDragOver = (e) => {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    isDragOverTextbox.value = true;
+};
+
+const onTextDragLeave = (e) => {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    dragDepth = Math.max(0, dragDepth - 1);
+    if (dragDepth === 0) {
+        isDragOverTextbox.value = false;
+    }
+};
+
+const onTextDrop = (e) => {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    dragDepth = 0;
+    isDragOverTextbox.value = false;
+    const files = e.dataTransfer?.files || [];
+    if (fileUploadRef.value && files.length > 0) {
+        fileUploadRef.value.processExternalFiles(files);
+    }
+};
+
+onMounted(() => {
+    _preventIfFiles = (e) => {
+        if (hasFiles(e)) {
+            e.preventDefault();
+        }
+    };
+    window.addEventListener('dragover', _preventIfFiles);
+    window.addEventListener('drop', _preventIfFiles);
+});
+
+onUnmounted(() => {
+    if (_preventIfFiles) {
+        window.removeEventListener('dragover', _preventIfFiles);
+        window.removeEventListener('drop', _preventIfFiles);
+    }
+});
 
 // CSRFトークンを取得する関数
 function getCsrfToken() {
@@ -37,24 +94,12 @@ function getCsrfToken() {
     return token;
 }
 
-// 画像変更時の処理
-const onImageChange = (event) => {
-    handleImageChange(event, image, imagePreview, localErrorMessage);
+// FileUploadイベント
+const handleFilesChanged = (files) => {
+    attachedFiles.value = files;
 };
-
-// ファイル選択ボタンをクリックしたときの処理
-const triggerFileInput = () => {
-    fileInput.value.click();
-};
-
-// 画像を削除する
-const removeImage = () => {
-    image.value = null; // 画像を削除
-    imagePreview.value = null; // 画像プレビューを削除
-    localErrorMessage.value = null; // エラーメッセージを削除
-    if (fileInput.value) {
-        fileInput.value.value = ""; // ファイル入力の値をリセット
-    }
+const handleFileUploadError = (msg) => {
+    localErrorMessage.value = msg;
 };
 
 // キャンセルボタン
@@ -78,19 +123,21 @@ const submitQuotePost = () => {
     formData.append("quoted_post_id", props.quotedPost.id); // 引用元の投稿IDを追加
     formData.append("_token", getCsrfToken()); // CSRFトークンを追加
 
-    // 画像データが存在する場合、フォームデータに追加
-    if (image.value) {
-        formData.append("image", image.value);
+    // 添付ファイル（統一システム）
+    if (attachedFiles.value.length > 0) {
+        attachedFiles.value.forEach((file, index) => {
+            formData.append(`files[${index}]`, file);
+        });
     }
 
     // 投稿の送信
     router.post(route("forum.store"), formData, {
         onSuccess: () => {
             // 投稿成功後の処理
-            newPostTitle.value = ""; // タイトルをリセット
-            newPostContent.value = ""; // 投稿内容をリセット
-            image.value = null; // 画像をリセット
-            imagePreview.value = null; // 画像プレビューをリセット
+            newPostTitle.value = "";
+            newPostContent.value = "";
+            if (fileUploadRef.value) fileUploadRef.value.reset();
+            attachedFiles.value = [];
             // 掲示板ページにリダイレクト
             router.get(route("forum.index", { forum_id: props.forumId }), {
                 preserveState: true, // ページの状態を保存
@@ -137,51 +184,47 @@ const truncatedMessage = computed(() => {
                     class="w-full p-2 pr-12 border border-gray-300 dark:border-gray-600 rounded mb-4 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
                     placeholder="投稿文を入力してください"
                     rows="4"
+                    ref="textAreaRef"
+                    @dragenter="onTextDragEnter"
+                    @dragover="onTextDragOver"
+                    @dragleave="onTextDragLeave"
+                    @drop="onTextDrop"
                 ></textarea>
-
-                <!-- 画像選択アイコン -->
-                <div
-                    class="absolute right-3 bottom-9 bg-gray-300 dark:bg-gray-600 text-black dark:text-gray-300 transition hover:bg-gray-400 dark:hover:bg-gray-500 hover:text-white rounded-md flex items-center justify-center cursor-pointer p-2"
+                <!-- 小さな添付ボタン（クリックで選択） -->
+                <button
+                    type="button"
+                    class="absolute right-3 bottom-9 bg-gray-300 dark:bg-gray-600 text-black dark:text-gray-300 transition hover:bg-gray-400 dark:hover:bg-gray-500 rounded-md flex items-center justify-center cursor-pointer p-2"
                     style="width: 40px; height: 40px"
-                    @click="triggerFileInput"
+                    @click="fileUploadRef?.openFileDialog()"
                     title="ファイルを選択"
                 >
-                    <i class="bi bi-card-image text-2xl"></i>
+                    <i class="bi bi-paperclip text-2xl"></i>
+                </button>
+
+                <!-- ドラッグ中のみ表示するオーバーレイのD&D UI -->
+                <div v-if="isDragOverTextbox" class="absolute inset-0 z-10 flex items-center justify-center">
+                    <div class="w-full h-full border-2 border-dashed border-blue-400 bg-blue-50/70 dark:bg-blue-900/30 rounded-md flex items-center justify-center">
+                        <div class="text-center text-blue-700 dark:text-blue-200">
+                            <i class="bi bi-paperclip text-3xl mb-2 block"></i>
+                            <p>ここにファイルをドロップして添付</p>
+                        </div>
+                    </div>
                 </div>
             </div>
 
-            <!-- 隠しファイル入力 -->
-            <input
-                type="file"
-                accept="image/*"
-                ref="fileInput"
-                @change="onImageChange"
-                style="display: none"
-            />
             <!-- エラーメッセージ表示 -->
             <div v-if="localErrorMessage" class="text-red-500 dark:text-red-400 mt-2">
                 {{ localErrorMessage }}
             </div>
-            <!-- プレビュー表示 -->
-            <div v-if="imagePreview" class="relative mt-2 inline-block">
-                <!-- プレビュー画像 -->
-                <img
-                    :src="imagePreview"
-                    alt="画像プレビュー"
-                    class="w-32 h-32 object-cover rounded-md cursor-pointer hover:opacity-80 transition"
-                    @click="isModalOpen = true"
+
+            <!-- 統一ファイル添付（ドロップUIは非表示、一覧・削除のみ） -->
+            <div class="mt-2">
+                <FileUpload
+                    ref="fileUploadRef"
+                    :showDropZone="false"
+                    @files-changed="handleFilesChanged"
+                    @error="handleFileUploadError"
                 />
-                <!-- プレビュー画像削除ボタン -->
-                <div
-                    class="absolute top-0 right-0 bg-white dark:bg-gray-800 rounded-full p-1 cursor-pointer flex items-center justify-center"
-                    @click="removeImage"
-                    title="画像を削除"
-                    style="width: 24px; height: 24px"
-                >
-                    <i
-                        class="bi bi-x-circle text-black dark:text-gray-300 hover:text-gray-500 dark:hover:text-gray-400"
-                    ></i>
-                </div>
             </div>
 
             <!-- 送信ボタン -->
@@ -200,14 +243,7 @@ const truncatedMessage = computed(() => {
                 </button>
             </div>
 
-            <!-- 引用投稿の画像モーダル -->
-            <ImageModal :isOpen="isModalOpen" @close="isModalOpen = false">
-                <img
-                    :src="imagePreview"
-                    alt="投稿画像"
-                    class="max-w-full max-h-full rounded-lg"
-                />
-            </ImageModal>
+            
         </div>
     </div>
 </template>


### PR DESCRIPTION
### 目的

- 引用付き投稿フォームを既存の統一Attachmentコンポーネント（）に統合し、画像専用のレガシー実装を排除する。
- 投稿体験（選択・ドラッグ&ドロップ・一覧/削除）のUI/UXを他フォームと一貫させ、メンテナンスコストと不具合の温床を削減する。

### 達成条件

- 引用投稿フォームで複数ファイルを添付可能（）で送信されること。
- 画像専用実装（//隠しfile input直叩き）が撤去されていること。
- D&Dはテキストエリア上のみ有効なガイドUIを表示し、ページ外遷移などの誤操作を防止すること。
- 送信成功時にフォームと添付状態がリセットされること（）。

### 実装の概要

- 
  - 画像専用の状態・処理（, , ,  等）を廃止。
  - 統一添付コンポーネント  を採用し、 で  に詰めて送信。
  - テキストエリア上のみD&DできるUIを追加（オーバーレイ表示、ドラッグ深度追跡、への防止で誤遷移を回避）。
  - 添付のエラーをローカルに反映するハンドラを追加。
  - 送信成功時にのを呼び出し、UIと状態を初期化。
- 
  - 親から直接ファイルを投入するための公開メソッド  を追加。
  - 親からファイル選択ダイアログを開く  を追加。

差分概要（origin/master..HEAD）:
- 2 files changed, 121 insertions(+), 74 deletions(-)
  -  (+11)
  -  (+184/-147 など、画像専用実装の削除と添付統一の導入)

### 対処したバグ

- ブラウザへ直接ファイルをドロップした際に発生し得るページ遷移・ファイルオープンを、のですることで予防。
- テキストエリア外での不意のD&D受付を抑止し、誤添付やUI干渉のリスクを軽減。

### 必要なかった実装

- 画像専用のプレビュー/モーダル（）
  - 採用を検討したが、統一Attachmentによりプレビュー仕様がフォーム間で分岐しUXが不整合になるため結果的に削除。
- 既存のユーティリティを用いた単一画像アップロード
  - 互換性維持のための暫定併存を検討したが、重複コードとバグ温床を増やすため結果的に見送り（へ統一）。
- フォーム全体をカバーする広域ドロップゾーン
  - ドロップターゲットが広すぎると誤操作を誘発する理由により、テキストエリア上のみのオーバーレイUIに限定。

### レビューしてほしいところ

- サーバ側の受け口が （複数）での受付に統一されているか（ のバリデーション/保存ロジックとの整合）。
- D&Dのグローバルが他画面で副作用を起こさないか（今回のコンポーネントunmountで確実に解除される想定）。
- モバイル環境での挙動（添付ボタンタップ、ドラッグ未対応環境のフォールバック）。
- アクセシビリティ（キーボード操作、スクリーンリーダーのラベル付けなど）。

### 不安に思っていること

- 既存投稿フォームがすでにで運用されている前提のため、引用フォームのみ→への切替が先行することによる一時的不整合リスク。
- 大容量ファイルの進捗表示は今回未実装のため、通信環境によっては体感遅延が生じる可能性。

### 保留していること

- 添付ファイルプレビュー（画像サムネイル、非画像のファイル種別アイコン）統一仕様の整備。
- アップロード進捗表示・キャンセル操作の導入。
- バリデーション/許可拡張子・容量制限の明文化（UIメッセージ含む）。
- i18n文言の整理と各コンポーネント横断の共通化。