### PR TITLE
ユーザー削除時の外部キー制約エラーを解消（attachments.uploaded_by を ON DELETE SET NULL）

### DIFF
--- a/database/migrations/2025_09_18_000001_update_attachments_uploaded_by_on_delete_set_null.php
+++ b/database/migrations/2025_09_18_000001_update_attachments_uploaded_by_on_delete_set_null.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        // MySQLのみ対象（テストはSQLiteのためスキップ）
+        if (Schema::getConnection()->getDriverName() !== 'mysql') {
+            return;
+        }
+
+        // 既存の外部キーを削除（名前はエラー文より既知）
+        DB::statement('ALTER TABLE `attachments` DROP FOREIGN KEY `attachments_uploaded_by_foreign`');
+
+        // カラムをNULL許可に変更
+        DB::statement('ALTER TABLE `attachments` MODIFY `uploaded_by` BIGINT UNSIGNED NULL');
+
+        // ON DELETE SET NULL で外部キーを再作成
+        DB::statement('ALTER TABLE `attachments`
+            ADD CONSTRAINT `attachments_uploaded_by_foreign`
+            FOREIGN KEY (`uploaded_by`) REFERENCES `users`(`id`) ON DELETE SET NULL');
+    }
+
+    public function down(): void
+    {
+        if (Schema::getConnection()->getDriverName() !== 'mysql') {
+            return;
+        }
+
+        // 元の状態に戻す（RESTRICT相当）
+        DB::statement('ALTER TABLE `attachments` DROP FOREIGN KEY `attachments_uploaded_by_foreign`');
+        DB::statement('ALTER TABLE `attachments` MODIFY `uploaded_by` BIGINT UNSIGNED NOT NULL');
+        DB::statement('ALTER TABLE `attachments`
+            ADD CONSTRAINT `attachments_uploaded_by_foreign`
+            FOREIGN KEY (`uploaded_by`) REFERENCES `users`(`id`)');
+    }
+};
+


### PR DESCRIPTION
### 目的

ユーザー削除時に `attachments.uploaded_by → users.id` の外部キー制約（RESTRICT）により削除がブロックされていた不具合を解消し、添付データを保持したまま安全にユーザーを削除できるようにする。

### 達成条件

- 添付を持つユーザーの削除が 1451 エラーなく成功する
- 削除後、該当添付の `uploaded_by` が `NULL` になっている
- 添付の表示・ダウンロードは引き続き可能
- 既存の権限ロジックにより、`uploaded_by = NULL` の添付は管理者のみ削除可能であること

### 実装の概要

- 新規マイグレーション追加（MySQLのみ適用）
  - 既存FK `attachments_uploaded_by_foreign` を DROP
  - `uploaded_by` を `NULL` 許可へ変更
  - FK を `ON DELETE SET NULL` で再作成
- 既存マイグレーションの書き換えは一切なし（ポリシー遵守）

### 対処したバグ

- SQLSTATE[23000]: Integrity constraint violation: 1451 により、添付を持つユーザーの削除ができない問題

### 必要なかった実装

- アプリ側でユーザー削除前に `attachments.uploaded_by` を `NULL` 更新する案：
  - 即効性はあるが、列が `NOT NULL` のままでは恒久対応にならず、DB整合性が担保されないため採用を見送り
- 既存マイグレーションの書き換え：
  - チームポリシー（既存マイグレーションの編集禁止）に反するため採用を見送り

### レビューしてほしいところ

- MySQL限定ガード（driver判定）の妥当性
- `down()` で RESTRICT 相当に戻す手順の正確性
- 他テーブルの `users.id` 参照で同様のRESTRICTが残っていないか（影響範囲の観点）

### 不安に思っていること

- 本番で過去に付与されたFK名が差異ある場合（環境差）にDROPが失敗する可能性
  - エラーログで検知できるが、必要に応じてFK名の実測確認が必要

### 保留していること

- `User` ソフトデリート化の検討（将来的な監査要件対応）
- `User` 削除時に「ユーザーのアイコン添付（attachable_type=User）」のみ安全に物理削除する運用の是非

