### PR TITLE
添付ファイルの安定化: 一時保存→確定保存 / GC / 制約統一（＋self-healオプション）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 /public/hot
 /public/storage
 /storage/*.key
+# Ignore all generated/storage files (tenant FS, attachments, caches, etc.)
+/storage/**
+!/storage/.gitignore
 /vendor
 .env
 .env.backup
@@ -20,4 +23,3 @@ yarn-error.log
 /.vscode
 my.cnf
 !database/migrations/*.php
-

--- a/app/Console/Commands/AttachmentsGc.php
+++ b/app/Console/Commands/AttachmentsGc.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Tenant;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class AttachmentsGc extends Command
+{
+    protected $signature = 'attachments:gc {--tenant=} {--days=1} {--dry-run}';
+    protected $description = 'attachmentsの一時領域(temp)と不要生成物をGC。--days=N より古いtempを削除。';
+
+    public function handle(): int
+    {
+        $tenantId = $this->option('tenant');
+        $days = (int) $this->option('days');
+        $dryRun = (bool) $this->option('dry-run');
+        $threshold = now()->subDays($days)->getTimestamp();
+
+        $tenants = $tenantId ? Tenant::where('id', $tenantId)->get() : Tenant::query()->get();
+        if ($tenants->isEmpty()) {
+            $this->info('対象テナントなし');
+            return self::SUCCESS;
+        }
+
+        $removed = 0; $checked = 0;
+        foreach ($tenants as $tenant) {
+            tenancy()->initialize($tenant);
+            $this->line("=== Tenant {$tenant->id} ===");
+
+            // temp配下の古いファイルを削除
+            $prefix = 'temp/attachments';
+            $dirs = Storage::disk('public')->directories('temp');
+            if (!in_array('temp/attachments', $dirs, true)) {
+                tenancy()->end();
+                continue;
+            }
+            $files = Storage::disk('public')->allFiles($prefix);
+            foreach ($files as $file) {
+                $checked++;
+                $last = Storage::disk('public')->lastModified($file);
+                if ($last < $threshold) {
+                    if ($dryRun) {
+                        $this->info("[DRY-RUN] delete temp: {$file}");
+                    } else {
+                        Storage::disk('public')->delete($file);
+                        $this->info("[DELETED] temp: {$file}");
+                    }
+                    $removed++;
+                }
+            }
+            tenancy()->end();
+        }
+
+        $this->line("=== Summary === checked={$checked}, removed={$removed}");
+        return self::SUCCESS;
+    }
+}
+

--- a/app/Console/Commands/RepairAttachmentFiles.php
+++ b/app/Console/Commands/RepairAttachmentFiles.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Attachment;
+use App\Models\Tenant;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class RepairAttachmentFiles extends Command
+{
+    protected $signature = 'attachments:repair-files {--tenant=} {--dry-run}';
+    protected $description = '中央/テナント間で保存先が不一致の添付ファイルを、テナント側に補正コピーする（dry-run対応）';
+
+    public function handle(): int
+    {
+        $tenantId = $this->option('tenant');
+        $dryRun = (bool) $this->option('dry-run');
+
+        $query = Attachment::query()->withoutGlobalScopes();
+        if ($tenantId) {
+            $query->where('tenant_id', $tenantId);
+        }
+
+        $attachments = $query->select('id', 'tenant_id', 'file_path')->orderBy('tenant_id')->get();
+        if ($attachments->isEmpty()) {
+            $this->info('対象の添付が見つかりません');
+            return self::SUCCESS;
+        }
+
+        $grouped = $attachments->groupBy('tenant_id');
+        $fixed = 0; $missing = 0; $skipped = 0;
+
+        foreach ($grouped as $tid => $items) {
+            $tenant = Tenant::find($tid);
+            if (!$tenant) {
+                $this->warn("テナントが見つかりません: {$tid}（skip）");
+                $skipped += $items->count();
+                continue;
+            }
+
+            // テナント初期化
+            tenancy()->initialize($tenant);
+            $this->line("=== Tenant: {$tid} ({$items->count()} files) ===");
+
+            foreach ($items as $att) {
+                $path = $att->file_path;
+                $tenantHas = Storage::disk('public')->exists($path);
+                if ($tenantHas) {
+                    continue; // OK
+                }
+
+                // 中央側に一時的に切り替えて存在確認＆取得
+                tenancy()->end();
+                $centralHas = Storage::disk('public')->exists($path);
+                $content = null;
+                if ($centralHas) {
+                    $content = Storage::disk('public')->get($path);
+                }
+                // 再度テナントを初期化
+                tenancy()->initialize($tenant);
+
+                if (!$centralHas) {
+                    $this->warn("[MISSING] id={$att->id} path={$path}");
+                    $missing++;
+                    continue;
+                }
+
+                if ($dryRun) {
+                    $this->info("[DRY-RUN] copy central -> tenant: id={$att->id} path={$path}");
+                    continue;
+                }
+
+                Storage::disk('public')->put($path, $content);
+                $this->info("[FIXED] id={$att->id} path={$path}");
+                $fixed++;
+            }
+
+            // 終了
+            tenancy()->end();
+        }
+
+        $this->line("=== Summary ===");
+        $this->line("fixed={$fixed}, missing={$missing}, skipped={$skipped}");
+        return self::SUCCESS;
+    }
+}
+

--- a/app/Http/Controllers/AttachmentController.php
+++ b/app/Http/Controllers/AttachmentController.php
@@ -34,7 +34,7 @@ class AttachmentController extends Controller
         $this->validateTenantAccess($attachment);
 
         // デバッグログ（保存/表示のFSコンテキスト不一致確認用）
-        try {
+        if (config('attachments.debug_log')) try {
             $host = request()->getHost();
             $userTenantId = optional(Auth::user())->tenant_id;
             $currentTenantId = function_exists('tenant') && tenant() ? tenant()->id : null;
@@ -91,7 +91,7 @@ class AttachmentController extends Controller
         // テナント境界チェック
         $this->validateTenantAccess($attachment);
 
-        try {
+        if (config('attachments.debug_log')) try {
             Log::info('Attachment destroy debug', [
                 'host' => request()->getHost(),
                 'env' => config('app.env'),

--- a/app/Http/Controllers/AttachmentController.php
+++ b/app/Http/Controllers/AttachmentController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use App\Exceptions\Custom\TenantViolationException;
 
@@ -24,10 +25,37 @@ class AttachmentController extends Controller
      * ファイル表示・ダウンロード用ルート
      * セキュアなファイルアクセスを提供
      */
-    public function show(Attachment $attachment): StreamedResponse
+    public function show($attachment): StreamedResponse
     {
+        // ルートモデルバインディング時のテナントスコープ影響を避け、明示的に取得
+        $attachment = Attachment::withoutGlobalScopes()->findOrFail($attachment);
+
         // テナント境界チェック
         $this->validateTenantAccess($attachment);
+
+        // デバッグログ（保存/表示のFSコンテキスト不一致確認用）
+        try {
+            $host = request()->getHost();
+            $userTenantId = optional(Auth::user())->tenant_id;
+            $currentTenantId = function_exists('tenant') && tenant() ? tenant()->id : null;
+            $diskRoot = config('filesystems.disks.public.root');
+            $path = $attachment->file_path;
+            $exists = Storage::disk('public')->exists($path);
+            Log::info('Attachment show debug', [
+                'host' => $host,
+                'env' => config('app.env'),
+                'route' => optional(request()->route())->getName(),
+                'user_tenant_id' => $userTenantId,
+                'current_tenant_id' => $currentTenantId,
+                'attachment_id' => $attachment->id,
+                'attachment_tenant_id' => $attachment->tenant_id,
+                'disk_root' => $diskRoot,
+                'file_path' => $path,
+                'exists' => $exists,
+            ]);
+        } catch (\Throwable $e) {
+            // ログ取得で例外が出ても本処理は継続
+        }
         
         // ファイル存在チェック
         if (!Storage::disk('public')->exists($attachment->file_path)) {
@@ -55,10 +83,27 @@ class AttachmentController extends Controller
     /**
      * ファイル削除
      */
-    public function destroy(Attachment $attachment): Response
+    public function destroy($attachment): Response
     {
+        // ルートモデルバインディング時のテナントスコープ影響を避け、明示的に取得
+        $attachment = Attachment::withoutGlobalScopes()->findOrFail($attachment);
+
         // テナント境界チェック
         $this->validateTenantAccess($attachment);
+
+        try {
+            Log::info('Attachment destroy debug', [
+                'host' => request()->getHost(),
+                'env' => config('app.env'),
+                'user_tenant_id' => optional(Auth::user())->tenant_id,
+                'current_tenant_id' => (function_exists('tenant') && tenant()) ? tenant()->id : null,
+                'attachment_id' => $attachment->id,
+                'attachment_tenant_id' => $attachment->tenant_id,
+                'file_path' => $attachment->file_path,
+            ]);
+        } catch (\Throwable $e) {
+            // no-op
+        }
         
         // 削除権限チェック（アップロード者または管理者のみ）
         $this->validateDeletePermission($attachment);

--- a/app/Http/Requests/Comment/CommentStoreRequest.php
+++ b/app/Http/Requests/Comment/CommentStoreRequest.php
@@ -31,6 +31,9 @@ class CommentStoreRequest extends FormRequest
             'parent_id' => 'nullable|exists:comments,id',
             'message' => 'required|string|max:1000',
             'img' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:10240',
+            // 統一ファイル添付システム対応
+            'files' => 'nullable|array|max:10',
+            'files.*' => 'nullable|file|mimes:jpeg,png,jpg,gif,webp,pdf,doc,docx,xls,xlsx,txt,csv|max:10240',
         ];
     }
 
@@ -51,6 +54,12 @@ class CommentStoreRequest extends FormRequest
             'img.image' => 'ファイルは画像である必要があります。',
             'img.mimes' => 'jpeg、png、jpg、gif形式のファイルのみアップロード可能です。',
             'img.max' => 'ファイルサイズは10MB以下にしてください。',
+            // 統一ファイル添付
+            'files.array' => 'ファイルは配列で送信してください。',
+            'files.max' => '一度に添付できるファイルは最大10個までです。',
+            'files.*.file' => 'ファイルが正しく選択されていません。',
+            'files.*.mimes' => 'サポートされていないファイル形式です。画像・PDF・文書ファイルのみアップロード可能です。',
+            'files.*.max' => 'ファイルサイズは10MB以下にしてください。',
         ];
     }
 }

--- a/app/Http/Requests/Post/PostStoreRequest.php
+++ b/app/Http/Requests/Post/PostStoreRequest.php
@@ -33,6 +33,7 @@ class PostStoreRequest extends FormRequest
             'quoted_post_id' => 'nullable|exists:posts,id',
             'img' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:10240',
             // 統一ファイル添付システム対応
+            'files' => 'nullable|array|max:10',
             'files.*' => 'nullable|file|mimes:jpeg,png,jpg,gif,webp,pdf,doc,docx,xls,xlsx,txt,csv|max:10240',
         ];
     }
@@ -70,6 +71,8 @@ class PostStoreRequest extends FormRequest
             'img.mimes' => 'jpeg、png、jpg、gif形式のファイルのみアップロード可能です。',
             'img.max' => 'ファイルサイズは10MB以下にしてください。',
             // 統一ファイル添付システム用メッセージ
+            'files.array' => 'ファイルは配列で送信してください。',
+            'files.max' => '一度に添付できるファイルは最大10個までです。',
             'files.*.file' => 'ファイルが正しく選択されていません。',
             'files.*.mimes' => 'サポートされていないファイル形式です。画像・PDF・文書ファイルのみアップロード可能です。',
             'files.*.max' => 'ファイルサイズは10MB以下にしてください。',

--- a/app/Services/AttachmentService.php
+++ b/app/Services/AttachmentService.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use App\Exceptions\Custom\TenantViolationException;
@@ -112,7 +113,8 @@ class AttachmentService
         
         // 安全なファイル名生成
         $fileName = $this->generateSafeFileName($originalName, $extension);
-        $filePath = $this->getStoragePath($fileType) . '/' . $fileName;
+        $finalPath = $this->getStoragePath($fileType) . '/' . $fileName;
+        $tempPath = 'temp/' . $finalPath;
         
         // ファイルハッシュ生成（重複検出用）
         $hash = hash_file('sha256', $file->getRealPath());
@@ -139,18 +141,18 @@ class AttachmentService
             // 続行して新規保存
         }
         
-        // Laravel Storage使用（推奨方法）
+        // Laravel Storage使用（まずは一時領域へ保存）
         Log::info('AttachmentService: Attempting to save file', [
-            'filePath' => $filePath,
+            'filePath' => $tempPath,
             'originalName' => $originalName,
             'fileSize' => $file->getSize()
         ]);
         
         try {
-            // Laravel Storageを使用してファイル保存
+            // 一時領域に保存（publicディスク内の temp/ 配下）
             $storedPath = $file->storeAs(
-                dirname($filePath), // ディレクトリパス（例: attachments/images）
-                basename($filePath), // ファイル名
+                dirname($tempPath), // ディレクトリパス（例: temp/attachments/images）
+                basename($tempPath), // ファイル名
                 'public' // ディスク
             );
             
@@ -159,7 +161,7 @@ class AttachmentService
             }
             
             // 保存確認
-            $actualFilePath = $storedPath;
+            $actualFilePath = $storedPath; // 現時点では temp パス
             $exists = Storage::disk('public')->exists($actualFilePath);
             $size = $exists ? Storage::disk('public')->size($actualFilePath) : 0;
             
@@ -172,7 +174,7 @@ class AttachmentService
             if (!$exists) {
                 throw new \RuntimeException('ファイル保存確認に失敗しました');
             }
-            
+        
         } catch (\Exception $e) {
             Log::error('AttachmentService: File save failed', [
                 'error' => $e->getMessage(),
@@ -181,13 +183,13 @@ class AttachmentService
             throw new \RuntimeException('ファイルの保存に失敗しました: ' . $e->getMessage());
         }
         
-        // Attachmentレコード作成
+        // Attachmentレコード作成（現時点では temp パスを保持）
         $attachment = Attachment::create([
             'attachable_type' => $attachableType,
             'attachable_id' => $attachableId,
             'original_name' => $originalName,
             'file_name' => $fileName,
-            'file_path' => $actualFilePath, // 実際の保存パスを使用
+            'file_path' => $actualFilePath, // 一時保存パスを保持
             'file_size' => $file->getSize(),
             'mime_type' => $mimeType,
             'file_type' => $fileType,
@@ -197,6 +199,38 @@ class AttachmentService
             'is_safe' => $this->performSecurityScan($file)
         ]);
         
+        // トランザクション確定後に本番パスへ移動し、レコードを更新
+        DB::afterCommit(function () use ($attachment, $tempPath, $finalPath) {
+            try {
+                if (Storage::disk('public')->exists($tempPath)) {
+                    // 親ディレクトリが無ければ作成
+                    $dir = dirname($finalPath);
+                    if (!Storage::disk('public')->exists($dir)) {
+                        Storage::disk('public')->makeDirectory($dir);
+                    }
+                    Storage::disk('public')->move($tempPath, $finalPath);
+                    $attachment->update(['file_path' => $finalPath]);
+                    Log::info('AttachmentService: Finalized attachment file move', [
+                        'id' => $attachment->id,
+                        'from' => $tempPath,
+                        'to' => $finalPath
+                    ]);
+                } else {
+                    Log::warning('AttachmentService: Temp file missing at finalize time', [
+                        'id' => $attachment->id,
+                        'tempPath' => $tempPath
+                    ]);
+                }
+            } catch (\Throwable $e) {
+                Log::error('AttachmentService: Finalize move failed', [
+                    'id' => $attachment->id,
+                    'from' => $tempPath,
+                    'to' => $finalPath,
+                    'error' => $e->getMessage()
+                ]);
+            }
+        });
+
         return $attachment;
     }
 

--- a/app/Services/AttachmentService.php
+++ b/app/Services/AttachmentService.php
@@ -142,7 +142,7 @@ class AttachmentService
         }
         
         // Laravel Storage使用（まずは一時領域へ保存）
-        Log::info('AttachmentService: Attempting to save file', [
+        if (config('attachments.debug_log')) Log::info('AttachmentService: Attempting to save file', [
             'filePath' => $tempPath,
             'originalName' => $originalName,
             'fileSize' => $file->getSize()
@@ -165,7 +165,7 @@ class AttachmentService
             $exists = Storage::disk('public')->exists($actualFilePath);
             $size = $exists ? Storage::disk('public')->size($actualFilePath) : 0;
             
-            Log::info('AttachmentService: File saved successfully', [
+            if (config('attachments.debug_log')) Log::info('AttachmentService: File saved successfully', [
                 'actualFilePath' => $actualFilePath,
                 'file_exists' => $exists,
                 'file_size' => $size
@@ -210,13 +210,13 @@ class AttachmentService
                     }
                     Storage::disk('public')->move($tempPath, $finalPath);
                     $attachment->update(['file_path' => $finalPath]);
-                    Log::info('AttachmentService: Finalized attachment file move', [
+                    if (config('attachments.debug_log')) Log::info('AttachmentService: Finalized attachment file move', [
                         'id' => $attachment->id,
                         'from' => $tempPath,
                         'to' => $finalPath
                     ]);
                 } else {
-                    Log::warning('AttachmentService: Temp file missing at finalize time', [
+                    if (config('attachments.debug_log')) Log::warning('AttachmentService: Temp file missing at finalize time', [
                         'id' => $attachment->id,
                         'tempPath' => $tempPath
                     ]);

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -149,7 +149,7 @@ class PostService
      */
     private function handleFileAttachments(PostStoreRequest $request, Post $post): void
     {
-        Log::info('=== handleFileAttachments Debug ===', [
+        if (config('attachments.debug_log')) Log::info('=== handleFileAttachments Debug ===', [
             'hasFile_image' => $request->hasFile('image'),
             'hasFile_files' => $request->hasFile('files'),
             'post_id' => $post->id
@@ -157,7 +157,7 @@ class PostService
         
         // レガシー画像フィールドの処理（後方互換性）
         if ($request->hasFile('image')) {
-            Log::info('Calling uploadSingleFile for image');
+            if (config('attachments.debug_log')) Log::info('Calling uploadSingleFile for image');
             $this->attachmentService->uploadSingleFile(
                 $request->file('image'),
                 'App\\Models\\Post',
@@ -167,7 +167,7 @@ class PostService
         
         // 新しい統一ファイル添付システム
         if ($request->hasFile('files')) {
-            Log::info('Calling uploadFiles for files array', [
+            if (config('attachments.debug_log')) Log::info('Calling uploadFiles for files array', [
                 'files_count' => count($request->file('files'))
             ]);
             $this->attachmentService->uploadFiles(

--- a/config/attachments.php
+++ b/config/attachments.php
@@ -3,5 +3,8 @@
 return [
     // 本番ではfalse、必要に応じて .env で ATTACHMENTS_DEBUG_LOG=true にする
     'debug_log' => env('ATTACHMENTS_DEBUG_LOG', false),
-];
 
+    // 表示時の自己修復（tenant FSに無ければ中央FSから1回だけコピーして配信）
+    // 本番では方針に応じて有効化を判断（既定: false）
+    'self_heal' => env('ATTACHMENTS_SELF_HEAL', false),
+];

--- a/config/attachments.php
+++ b/config/attachments.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    // 本番ではfalse、必要に応じて .env で ATTACHMENTS_DEBUG_LOG=true にする
+    'debug_log' => env('ATTACHMENTS_DEBUG_LOG', false),
+];
+

--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -103,6 +103,7 @@ return [
         'suffix_base' => 'tenant',
         'disks' => [
             'local',
+            'public',
             // 's3',
         ],
 

--- a/docs/attachments-ops.md
+++ b/docs/attachments-ops.md
@@ -1,0 +1,48 @@
+# 添付ファイル運用（Repair / GC / 一時保存）
+
+## 一時保存→確定保存（フェーズ1）
+
+- 新規アップロードは `public/temp/attachments/...` に保存し、DBコミット後に `public/attachments/...` へ移動します。
+- 投稿が失敗・キャンセルされた場合、tempに残ったファイルは GC で削除されます。
+
+## Repair（中央→テナントの補修コピー）
+
+壊れ添付（DBにあるがテナントFSに実体がない）を中央FSからテナントFSへ補修します。
+
+```
+# 影響確認（dry-run）
+sail php artisan attachments:repair-files --dry-run
+
+# テナント限定
+sail php artisan attachments:repair-files --tenant=<tenant_id> --dry-run
+
+# 実行（dry-runで問題なければ）
+sail php artisan attachments:repair-files
+```
+
+- [FIXED]: 補修コピー成功。以後は表示可能。
+- [MISSING]: 実体が無いため再アップロードが必要。
+
+## GC（ガーベジコレクション）
+
+temp 配下の古い一時ファイルを削除します。デフォルトは 1 日以上経過。
+
+```
+# 影響確認（dry-run）
+sail php artisan attachments:gc --days=1 --dry-run
+
+# 実行
+sail php artisan attachments:gc --days=1
+```
+
+スケジュール実行：毎日 03:10（routes/console.php 参照）。
+
+## ログ抑制
+
+`.env` で `ATTACHMENTS_DEBUG_LOG=false`（既定）にするとデバッグログを出しません。
+
+## 制約の統一
+
+- バックエンド：Post/Comment の Request で `files`（最大10） と `files.*`（各10MB）を検証。
+- フロント：FileUpload で `maxFiles=10`、各10MBに到達前にUIで抑止。
+

--- a/docs/attachments-ops.md
+++ b/docs/attachments-ops.md
@@ -41,8 +41,20 @@ sail php artisan attachments:gc --days=1
 
 `.env` で `ATTACHMENTS_DEBUG_LOG=false`（既定）にするとデバッグログを出しません。
 
+## Self-heal（オプション）
+
+表示時にテナントFSにファイルが無い場合、中央FSから1回だけコピーして配信します。
+
+```
+# 有効化
+ATTACHMENTS_SELF_HEAL=true
+```
+
+注意:
+- 境界を跨がないよう、必ず `tenant()` の初期化・終了を正しく行います。
+- 監査ログ（debug_log=true 時に詳細）を確認できます。
+
 ## 制約の統一
 
 - バックエンド：Post/Comment の Request で `files`（最大10） と `files.*`（各10MB）を検証。
 - フロント：FileUpload で `maxFiles=10`、各10MBに到達前にUIで抑止。
-

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -199,7 +199,7 @@ const handleCancel = () => {
                     ></textarea>
                     <button
                         type="button"
-                        class="absolute right-3 bottom-9 bg-gray-300 dark:bg-gray-600 text-black dark:text-gray-300 transition hover:bg-gray-400 dark:hover:bg-gray-500 rounded-md flex items-center justify-center cursor-pointer p-2"
+                        class="absolute right-3 bottom-5 bg-gray-300 dark:bg-gray-600 text-black dark:text-gray-300 transition hover:bg-gray-400 dark:hover:bg-gray-500 rounded-md flex items-center justify-center cursor-pointer p-2"
                         style="width: 40px; height: 40px"
                         @click="fileUploadRef?.openFileDialog()"
                         title="ファイルを選択"

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -59,6 +59,9 @@ const fileUploadRef = ref(null);
 const attachedFiles = ref([]);
 const useUnifiedUpload = ref(true); // 統一システムの使用フラグ
 
+// クリップアイコンクリックでファイルダイアログを開く
+// アイコンから直接 fileUploadRef を呼び出すため追加の関数は不要
+
 // コンポーネントのマウント時に初期値を設定
 onMounted(() => {
     // コメントに対する返信の場合のみメンションを追加
@@ -185,14 +188,25 @@ const handleCancel = () => {
         <!-- コメントフォーム -->
         <form @submit.prevent="submitComment" enctype="multipart/form-data">
             <div>
-                <!-- コメントメッセージ入力欄 -->
-                <textarea
-                    v-model="commentData.message"
-                    class="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-                    required
-                    :placeholder="placeholder"
-                    rows="3"
-                ></textarea>
+                <!-- コメントメッセージ入力欄（クリップアイコン付き） -->
+                <div class="relative">
+                    <textarea
+                        v-model="commentData.message"
+                        class="w-full p-2 pr-12 pb-12 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+                        required
+                        :placeholder="placeholder"
+                        rows="3"
+                    ></textarea>
+                    <button
+                        type="button"
+                        class="absolute right-3 bottom-9 bg-gray-300 dark:bg-gray-600 text-black dark:text-gray-300 transition hover:bg-gray-400 dark:hover:bg-gray-500 rounded-md flex items-center justify-center cursor-pointer p-2"
+                        style="width: 40px; height: 40px"
+                        @click="fileUploadRef?.openFileDialog()"
+                        title="ファイルを選択"
+                    >
+                        <i class="bi bi-paperclip text-2xl"></i>
+                    </button>
+                </div>
             </div>
 
             <!-- 統一ファイル添付システム -->

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -4,6 +4,7 @@ import { router } from "@inertiajs/vue3";
 import { getCsrfToken } from "@/Utils/csrf";
 import ImageModal from "./ImageModal.vue";
 import FileUpload from "./FileUpload.vue"; // 統一ファイル添付コンポーネント
+import TextareaWithAttach from "./TextareaWithAttach.vue";
 import { handleImageChange } from "@/Utils/imageHandler";
 
 // コメントフォームのプロパティを定義
@@ -188,25 +189,12 @@ const handleCancel = () => {
         <!-- コメントフォーム -->
         <form @submit.prevent="submitComment" enctype="multipart/form-data">
             <div>
-                <!-- コメントメッセージ入力欄（クリップアイコン付き） -->
-                <div class="relative">
-                    <textarea
-                        v-model="commentData.message"
-                        class="w-full p-2 pr-12 pb-12 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-                        required
-                        :placeholder="placeholder"
-                        rows="3"
-                    ></textarea>
-                    <button
-                        type="button"
-                        class="absolute right-3 bottom-5 bg-gray-300 dark:bg-gray-600 text-black dark:text-gray-300 transition hover:bg-gray-400 dark:hover:bg-gray-500 rounded-md flex items-center justify-center cursor-pointer p-2"
-                        style="width: 40px; height: 40px"
-                        @click="fileUploadRef?.openFileDialog()"
-                        title="ファイルを選択"
-                    >
-                        <i class="bi bi-paperclip text-2xl"></i>
-                    </button>
-                </div>
+                <TextareaWithAttach
+                    v-model="commentData.message"
+                    :rows="3"
+                    :placeholder="placeholder"
+                    @attach-click="fileUploadRef?.openFileDialog()"
+                />
             </div>
 
             <!-- 統一ファイル添付システム -->

--- a/resources/js/Components/DropOverlay.vue
+++ b/resources/js/Components/DropOverlay.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="absolute inset-0 z-20 flex items-center justify-center">
+  <div class="absolute inset-0 z-20 flex items-center justify-center pointer-events-none">
     <div class="w-full h-full border-2 border-dashed border-blue-400 bg-blue-50/70 dark:bg-blue-900/30 rounded-md flex items-center justify-center">
       <div class="text-center text-blue-700 dark:text-blue-200">
         <i class="bi bi-paperclip text-3xl mb-2 block"></i>
@@ -12,4 +12,3 @@
 <script setup>
 // 見た目のみのオーバーレイ
 </script>
-

--- a/resources/js/Components/DropOverlay.vue
+++ b/resources/js/Components/DropOverlay.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="absolute inset-0 z-20 flex items-center justify-center">
+    <div class="w-full h-full border-2 border-dashed border-blue-400 bg-blue-50/70 dark:bg-blue-900/30 rounded-md flex items-center justify-center">
+      <div class="text-center text-blue-700 dark:text-blue-200">
+        <i class="bi bi-paperclip text-3xl mb-2 block"></i>
+        <p>ここにファイルをドロップして添付</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+// 見た目のみのオーバーレイ
+</script>
+

--- a/resources/js/Components/FileUpload.vue
+++ b/resources/js/Components/FileUpload.vue
@@ -69,6 +69,8 @@ export default {
   props: {
     // パネルの表示/非表示（機能は常時有効）
     visible: { type: Boolean, default: true },
+    // 最大ファイル数（制約統一: 10）
+    maxFiles: { type: Number, default: 10 },
   },
 
   data() {
@@ -114,8 +116,15 @@ export default {
       this.clearError()
       
       const validFiles = []
+
+      // 件数上限チェック（既存+追加がmaxFilesを超えないように）
+      const remaining = this.maxFiles - this.files.length
+      if (newFiles.length > remaining) {
+        this.showError(`一度に添付できるファイルは最大${this.maxFiles}個までです`)
+      }
+      const slice = newFiles.slice(0, Math.max(0, remaining))
       
-      for (const file of newFiles) {
+      for (const file of slice) {
         if (this.validateFile(file)) {
           validFiles.push(file)
         }

--- a/resources/js/Components/FileUpload.vue
+++ b/resources/js/Components/FileUpload.vue
@@ -1,34 +1,5 @@
 <template>
-  <div class="file-upload-container" v-show="visible">
-    <!-- ドラッグ&ドロップエリア -->
-    <div
-      @drop="handleDrop"
-      @dragover.prevent
-      @dragenter.prevent
-      :class="[
-        'drag-drop-area',
-        { 'drag-over': isDragging, 'has-error': hasError }
-      ]"
-      @dragenter="isDragging = true"
-      @dragleave="isDragging = false"
-    >
-      <div class="drag-drop-content">
-        <i class="bi bi-paperclip drag-drop-icon"></i>
-        <p class="drag-drop-text">
-          ファイルをドラッグ&ドロップ または
-          <button 
-            type="button" 
-            @click="$refs.fileInput.click()"
-            class="file-select-button"
-          >
-            ファイルを選択
-          </button>
-        </p>
-        <p class="file-types-hint">
-          対応形式: 画像, PDF, Word, Excel, テキスト (最大10MB)
-        </p>
-      </div>
-    </div>
+  <div class="file-upload-container">
 
     <!-- 隠しファイル入力 -->
     <input
@@ -47,7 +18,7 @@
     </div>
 
     <!-- アップロード済みファイル一覧 -->
-    <div v-if="files.length > 0" class="uploaded-files">
+    <div v-if="files.length > 0" v-show="visible" class="uploaded-files">
       <h4 class="uploaded-files-title">
         <i class="bi bi-files"></i>
         添付ファイル ({{ files.length }})
@@ -103,7 +74,6 @@ export default {
   data() {
     return {
       files: [],
-      isDragging: false,
       hasError: false,
       errorMessage: '',
       acceptedTypes: '.jpg,.jpeg,.png,.gif,.webp,.pdf,.doc,.docx,.xls,.xlsx,.txt,.csv',
@@ -135,14 +105,6 @@ export default {
     openFileDialog() {
       if (this.$refs.fileInput) this.$refs.fileInput.click()
     },
-    handleDrop(e) {
-      e.preventDefault()
-      this.isDragging = false
-      
-      const droppedFiles = Array.from(e.dataTransfer.files)
-      this.processFiles(droppedFiles)
-    },
-
     handleFileSelect(e) {
       const selectedFiles = Array.from(e.target.files)
       this.processFiles(selectedFiles)
@@ -275,49 +237,7 @@ export default {
 </script>
 
 <style scoped>
-.file-upload-container {
-  @apply space-y-4;
-}
-
-.drag-drop-area {
-  @apply border-2 border-dashed border-gray-300 rounded-lg p-8 text-center transition-all duration-200;
-  min-height: 120px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.drag-drop-area:hover {
-  @apply border-blue-400 bg-blue-50;
-}
-
-.drag-drop-area.drag-over {
-  @apply border-blue-500 bg-blue-100;
-}
-
-.drag-drop-area.has-error {
-  @apply border-red-400 bg-red-50;
-}
-
-.drag-drop-content {
-  @apply space-y-2;
-}
-
-.drag-drop-icon {
-  @apply text-4xl text-gray-400 mb-2;
-}
-
-.drag-drop-text {
-  @apply text-gray-600 font-medium;
-}
-
-.file-select-button {
-  @apply text-blue-600 underline hover:text-blue-800 font-medium;
-}
-
-.file-types-hint {
-  @apply text-sm text-gray-500;
-}
+.file-upload-container { @apply space-y-4; }
 
 .hidden-file-input {
   display: none;

--- a/resources/js/Components/FileUpload.vue
+++ b/resources/js/Components/FileUpload.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="file-upload-container">
+  <div class="file-upload-container" v-show="visible">
     <!-- ドラッグ&ドロップエリア -->
     <div
       @drop="handleDrop"
@@ -95,6 +95,11 @@ export default {
   name: 'FileUpload',
   emits: ['files-changed', 'error'],
   
+  props: {
+    // パネルの表示/非表示（機能は常時有効）
+    visible: { type: Boolean, default: true },
+  },
+
   data() {
     return {
       files: [],

--- a/resources/js/Components/PostForm.vue
+++ b/resources/js/Components/PostForm.vue
@@ -4,6 +4,7 @@ import { router } from "@inertiajs/vue3";
 import { getCsrfToken } from "@/Utils/csrf";
 import ImageModal from "./ImageModal.vue"; // ImageModalコンポーネントをインポート
 import FileUpload from "./FileUpload.vue"; // 統一ファイル添付コンポーネント
+import TextareaWithAttach from "./TextareaWithAttach.vue";
 import { handleImageChange } from "@/Utils/imageHandler";
 
 const props = defineProps({
@@ -169,25 +170,15 @@ const resetForm = () => {
             <!-- 本文 -->
             <div class="flex flex-col mt-2">
                 <p class="font-medium text-gray-900 dark:text-gray-100">本文</p>
-                <!-- テキスト入力ボックス（クリップアイコン付き） -->
-                <div class="relative">
-                    <textarea
-                        v-model="postData.message"
-                        class="w-full p-2 pr-12 pb-12 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
-                        required
-                        placeholder="本文を入力してください"
-                        rows="3"
-                    ></textarea>
-                    <button
-                        type="button"
-                        class="absolute right-3 bottom-5 bg-gray-300 dark:bg-gray-600 text-black dark:text-gray-300 transition hover:bg-gray-400 dark:hover:bg-gray-500 rounded-md flex items-center justify-center cursor-pointer p-2"
-                        style="width: 40px; height: 40px"
-                        @click="fileUploadRef?.openFileDialog()"
-                        title="ファイルを選択"
-                    >
-                        <i class="bi bi-paperclip text-2xl"></i>
-                    </button>
-                </div>
+                <TextareaWithAttach
+                    v-model="postData.message"
+                    :rows="3"
+                    placeholder="本文を入力してください"
+                    :textarea-class="'w-full p-2 pr-12 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100'"
+                    button-title="ファイルを選択"
+                    button-aria-label="ファイルを選択"
+                    @attach-click="fileUploadRef?.openFileDialog()"
+                />
             </div>
 
             <!-- 統一ファイル添付システム -->

--- a/resources/js/Components/PostForm.vue
+++ b/resources/js/Components/PostForm.vue
@@ -27,6 +27,9 @@ const fileUploadRef = ref(null);
 const attachedFiles = ref([]);
 const useUnifiedUpload = ref(true); // 統一システムの使用フラグ
 
+// クリップアイコンクリックでファイルダイアログを開く
+// アイコンから直接 fileUploadRef を呼び出すため追加の関数は不要
+
 // forumIdの変更を監視し、postDataに反映
 watch(
     () => props.forumId,
@@ -166,14 +169,25 @@ const resetForm = () => {
             <!-- 本文 -->
             <div class="flex flex-col mt-2">
                 <p class="font-medium text-gray-900 dark:text-gray-100">本文</p>
-                <!-- テキスト入力ボックス -->
-                <textarea
-                    v-model="postData.message"
-                    class="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
-                    required
-                    placeholder="本文を入力してください"
-                    rows="3"
-                ></textarea>
+                <!-- テキスト入力ボックス（クリップアイコン付き） -->
+                <div class="relative">
+                    <textarea
+                        v-model="postData.message"
+                        class="w-full p-2 pr-12 pb-12 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                        required
+                        placeholder="本文を入力してください"
+                        rows="3"
+                    ></textarea>
+                    <button
+                        type="button"
+                        class="absolute right-3 bottom-9 bg-gray-300 dark:bg-gray-600 text-black dark:text-gray-300 transition hover:bg-gray-400 dark:hover:bg-gray-500 rounded-md flex items-center justify-center cursor-pointer p-2"
+                        style="width: 40px; height: 40px"
+                        @click="fileUploadRef?.openFileDialog()"
+                        title="ファイルを選択"
+                    >
+                        <i class="bi bi-paperclip text-2xl"></i>
+                    </button>
+                </div>
             </div>
 
             <!-- 統一ファイル添付システム -->

--- a/resources/js/Components/PostForm.vue
+++ b/resources/js/Components/PostForm.vue
@@ -184,6 +184,7 @@ const resetForm = () => {
                         :textarea-class="'w-full p-2 pr-12 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100'"
                         button-title="ファイルを選択"
                         button-aria-label="ファイルを選択"
+                        :drag-active="isDragOver"
                         @attach-click="fileUploadRef?.openFileDialog()"
                         @dragenter="onTextDragEnter"
                         @dragover="onTextDragOver"

--- a/resources/js/Components/PostForm.vue
+++ b/resources/js/Components/PostForm.vue
@@ -200,7 +200,7 @@ const resetForm = () => {
             <div class="mt-4">
                 <FileUpload 
                     ref="fileUploadRef"
-                    :visible="false"
+                    :visible="isDragOver || (attachedFiles && attachedFiles.length > 0)"
                     @files-changed="handleFilesChanged"
                     @error="handleFileUploadError"
                 />

--- a/resources/js/Components/PostForm.vue
+++ b/resources/js/Components/PostForm.vue
@@ -180,7 +180,7 @@ const resetForm = () => {
                     ></textarea>
                     <button
                         type="button"
-                        class="absolute right-3 bottom-9 bg-gray-300 dark:bg-gray-600 text-black dark:text-gray-300 transition hover:bg-gray-400 dark:hover:bg-gray-500 rounded-md flex items-center justify-center cursor-pointer p-2"
+                        class="absolute right-3 bottom-5 bg-gray-300 dark:bg-gray-600 text-black dark:text-gray-300 transition hover:bg-gray-400 dark:hover:bg-gray-500 rounded-md flex items-center justify-center cursor-pointer p-2"
                         style="width: 40px; height: 40px"
                         @click="fileUploadRef?.openFileDialog()"
                         title="ファイルを選択"

--- a/resources/js/Components/QuotePostForm.vue
+++ b/resources/js/Components/QuotePostForm.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { router } from "@inertiajs/vue3";
 import FileUpload from "./FileUpload.vue";
+import TextareaWithAttach from "./TextareaWithAttach.vue";
 
 // 引用付き投稿フォームのprops
 const props = defineProps({
@@ -183,30 +184,19 @@ const truncatedMessage = computed(() => {
                 </p>
             </div>
 
-            <!-- 新しい投稿の入力フォーム -->
-            <div class="relative">
-                <textarea
+            <!-- 新しい投稿の入力フォーム（共通コンポーネント使用） -->
+            <div class="relative mb-4">
+                <TextareaWithAttach
                     v-model="newPostContent"
-                    class="w-full p-2 pr-12 border border-gray-300 dark:border-gray-600 rounded mb-4 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+                    :rows="4"
                     placeholder="投稿文を入力してください"
-                    rows="4"
-                    ref="textAreaRef"
+                    @attach-click="fileUploadRef?.openFileDialog()"
                     @dragenter="onTextDragEnter"
                     @dragover="onTextDragOver"
                     @dragleave="onTextDragLeave"
                     @drop="onTextDrop"
                     @mouseleave="onTextMouseLeave"
-                ></textarea>
-                <!-- 小さな添付ボタン（クリックで選択） -->
-                <button
-                    type="button"
-                    class="absolute right-3 bottom-9 bg-gray-300 dark:bg-gray-600 text-black dark:text-gray-300 transition hover:bg-gray-400 dark:hover:bg-gray-500 rounded-md flex items-center justify-center cursor-pointer p-2"
-                    style="width: 40px; height: 40px"
-                    @click="fileUploadRef?.openFileDialog()"
-                    title="ファイルを選択"
-                >
-                    <i class="bi bi-paperclip text-2xl"></i>
-                </button>
+                />
 
                 <!-- ドラッグ中のみ表示するオーバーレイのD&D UI -->
                 <div v-if="isDragOverTextbox" class="absolute inset-0 z-10 flex items-center justify-center">

--- a/resources/js/Components/QuotePostForm.vue
+++ b/resources/js/Components/QuotePostForm.vue
@@ -190,6 +190,7 @@ const truncatedMessage = computed(() => {
                     v-model="newPostContent"
                     :rows="4"
                     placeholder="投稿文を入力してください"
+                    :drag-active="isDragOverTextbox"
                     @attach-click="fileUploadRef?.openFileDialog()"
                     @dragenter="onTextDragEnter"
                     @dragover="onTextDragOver"
@@ -199,7 +200,7 @@ const truncatedMessage = computed(() => {
                 />
 
                 <!-- ドラッグ中のみ表示するオーバーレイのD&D UI -->
-                <div v-if="isDragOverTextbox" class="absolute inset-0 z-10 flex items-center justify-center">
+                <div v-if="isDragOverTextbox" class="absolute inset-0 z-10 flex items-center justify-center pointer-events-none">
                     <div class="w-full h-full border-2 border-dashed border-blue-400 bg-blue-50/70 dark:bg-blue-900/30 rounded-md flex items-center justify-center">
                         <div class="text-center text-blue-700 dark:text-blue-200">
                             <i class="bi bi-paperclip text-3xl mb-2 block"></i>

--- a/resources/js/Components/TextareaWithAttach.vue
+++ b/resources/js/Components/TextareaWithAttach.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, toRefs, useAttrs } from 'vue'
+defineOptions({ inheritAttrs: false })
 
 // このコンポーネントはテキストエリア右下に添付ボタンを重ねる共通UI
 // - 親から v-model で値を受け取る
@@ -12,7 +13,7 @@ const props = defineProps({
   rows: { type: Number, default: 3 },
   textareaClass: { type: String, default: 'w-full p-2 pr-12 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100' },
   rightOffsetClass: { type: String, default: 'right-3' },
-  bottomOffsetClass: { type: String, default: 'bottom-9' },
+  bottomOffsetClass: { type: String, default: 'bottom-5' },
   buttonTitle: { type: String, default: 'ファイルを選択' },
   buttonAriaLabel: { type: String, default: 'ファイルを選択' },
 })
@@ -49,4 +50,3 @@ const valueProxy = computed({
     </button>
   </div>
 </template>
-

--- a/resources/js/Components/TextareaWithAttach.vue
+++ b/resources/js/Components/TextareaWithAttach.vue
@@ -16,6 +16,7 @@ const props = defineProps({
   bottomOffsetClass: { type: String, default: 'bottom-5' },
   buttonTitle: { type: String, default: 'ファイルを選択' },
   buttonAriaLabel: { type: String, default: 'ファイルを選択' },
+  dragActive: { type: Boolean, default: false },
 })
 
 const emit = defineEmits(['update:modelValue', 'attach-click'])
@@ -40,7 +41,7 @@ const valueProxy = computed({
     <button
       type="button"
       class="absolute bg-gray-300 dark:bg-gray-600 text-black dark:text-gray-300 transition hover:bg-gray-400 dark:hover:bg-gray-500 rounded-md flex items-center justify-center cursor-pointer p-2"
-      :class="[rightOffsetClass, bottomOffsetClass]"
+      :class="[rightOffsetClass, bottomOffsetClass, { 'pointer-events-none': dragActive }]"
       style="width: 40px; height: 40px"
       :title="buttonTitle"
       :aria-label="buttonAriaLabel"

--- a/resources/js/Components/TextareaWithAttach.vue
+++ b/resources/js/Components/TextareaWithAttach.vue
@@ -1,0 +1,52 @@
+<script setup>
+import { computed, toRefs, useAttrs } from 'vue'
+
+// このコンポーネントはテキストエリア右下に添付ボタンを重ねる共通UI
+// - 親から v-model で値を受け取る
+// - 添付ボタンクリック時に attach-click をemit（親で fileUploadRef.openFileDialog() を呼ぶ）
+// - 任意のリスナー（dragenter/over/leave/drop など）は $attrs 経由でtextareaに転送
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+  placeholder: { type: String, default: '' },
+  rows: { type: Number, default: 3 },
+  textareaClass: { type: String, default: 'w-full p-2 pr-12 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100' },
+  rightOffsetClass: { type: String, default: 'right-3' },
+  bottomOffsetClass: { type: String, default: 'bottom-9' },
+  buttonTitle: { type: String, default: 'ファイルを選択' },
+  buttonAriaLabel: { type: String, default: 'ファイルを選択' },
+})
+
+const emit = defineEmits(['update:modelValue', 'attach-click'])
+const attrs = useAttrs()
+
+const valueProxy = computed({
+  get: () => props.modelValue,
+  set: (v) => emit('update:modelValue', v)
+})
+
+</script>
+
+<template>
+  <div class="relative">
+    <textarea
+      v-model="valueProxy"
+      :rows="rows"
+      :placeholder="placeholder"
+      :class="textareaClass"
+      v-bind="attrs"
+    ></textarea>
+    <button
+      type="button"
+      class="absolute bg-gray-300 dark:bg-gray-600 text-black dark:text-gray-300 transition hover:bg-gray-400 dark:hover:bg-gray-500 rounded-md flex items-center justify-center cursor-pointer p-2"
+      :class="[rightOffsetClass, bottomOffsetClass]"
+      style="width: 40px; height: 40px"
+      :title="buttonTitle"
+      :aria-label="buttonAriaLabel"
+      @click="$emit('attach-click')"
+    >
+      <i class="bi bi-paperclip text-2xl"></i>
+    </button>
+  </div>
+</template>
+

--- a/resources/js/Utils/useFileDragHover.js
+++ b/resources/js/Utils/useFileDragHover.js
@@ -6,6 +6,25 @@ export function useFileDragHover(dropCallback) {
   const isDragOver = ref(false)
   let dragDepth = 0
   let _preventIfFiles
+  let hideTimer = null // タイマーID
+
+  // 即座に表示する
+  const setVisible = () => {
+    if (hideTimer) { //もし非表示タイマーがあればキャンセル
+      clearTimeout(hideTimer) // タイマークリア
+      hideTimer = null // タイマーIDクリア
+    }
+    isDragOver.value = true // ドラッグオーバー状態に
+  }
+
+  // 指定時間後に非表示にする
+  const scheduleHide = (delay = 100) => {
+    if (hideTimer) clearTimeout(hideTimer)
+    hideTimer = setTimeout(() => {
+      isDragOver.value = false
+      hideTimer = null
+    }, delay)
+  }
 
   const hasFiles = (e) => {
     const types = e?.dataTransfer?.types
@@ -16,13 +35,13 @@ export function useFileDragHover(dropCallback) {
     if (!hasFiles(e)) return
     e.preventDefault()
     dragDepth++
-    isDragOver.value = true
+    setVisible() // 即座に表示
   }
 
   const onTextDragOver = (e) => {
     if (!hasFiles(e)) return
     e.preventDefault()
-    isDragOver.value = true
+    setVisible() // 即座に表示
   }
 
   const onTextDragLeave = (e) => {
@@ -30,7 +49,7 @@ export function useFileDragHover(dropCallback) {
     e.preventDefault()
     dragDepth = Math.max(0, dragDepth - 1)
     if (dragDepth === 0) {
-      isDragOver.value = false
+      scheduleHide(120)
     }
   }
 
@@ -38,6 +57,10 @@ export function useFileDragHover(dropCallback) {
     if (!hasFiles(e)) return
     e.preventDefault()
     dragDepth = 0
+    if (hideTimer) { //もし非表示タイマーがあればキャンセル
+      clearTimeout(hideTimer)
+      hideTimer = null
+    }
     isDragOver.value = false
     const files = e.dataTransfer?.files || []
     if (files && files.length > 0 && typeof dropCallback === 'function') {
@@ -74,4 +97,3 @@ export function useFileDragHover(dropCallback) {
     onTextMouseLeave,
   }
 }
-

--- a/resources/js/Utils/useFileDragHover.js
+++ b/resources/js/Utils/useFileDragHover.js
@@ -1,0 +1,77 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+
+// 共通ドラッグホバー検知フック
+// - dropCallback: (FileList|Array<File>) => void を受け取り、ドロップ時に呼ばれる
+export function useFileDragHover(dropCallback) {
+  const isDragOver = ref(false)
+  let dragDepth = 0
+  let _preventIfFiles
+
+  const hasFiles = (e) => {
+    const types = e?.dataTransfer?.types
+    return types && (types.includes && types.includes('Files'))
+  }
+
+  const onTextDragEnter = (e) => {
+    if (!hasFiles(e)) return
+    e.preventDefault()
+    dragDepth++
+    isDragOver.value = true
+  }
+
+  const onTextDragOver = (e) => {
+    if (!hasFiles(e)) return
+    e.preventDefault()
+    isDragOver.value = true
+  }
+
+  const onTextDragLeave = (e) => {
+    if (!hasFiles(e)) return
+    e.preventDefault()
+    dragDepth = Math.max(0, dragDepth - 1)
+    if (dragDepth === 0) {
+      isDragOver.value = false
+    }
+  }
+
+  const onTextDrop = (e) => {
+    if (!hasFiles(e)) return
+    e.preventDefault()
+    dragDepth = 0
+    isDragOver.value = false
+    const files = e.dataTransfer?.files || []
+    if (files && files.length > 0 && typeof dropCallback === 'function') {
+      dropCallback(files)
+    }
+  }
+
+  const onTextMouseLeave = () => {
+    dragDepth = 0
+    isDragOver.value = false
+  }
+
+  onMounted(() => {
+    _preventIfFiles = (e) => {
+      if (hasFiles(e)) e.preventDefault()
+    }
+    window.addEventListener('dragover', _preventIfFiles)
+    window.addEventListener('drop', _preventIfFiles)
+  })
+
+  onUnmounted(() => {
+    if (_preventIfFiles) {
+      window.removeEventListener('dragover', _preventIfFiles)
+      window.removeEventListener('drop', _preventIfFiles)
+    }
+  })
+
+  return {
+    isDragOver,
+    onTextDragEnter,
+    onTextDragOver,
+    onTextDragLeave,
+    onTextDrop,
+    onTextMouseLeave,
+  }
+}
+

--- a/routes/console.php
+++ b/routes/console.php
@@ -15,3 +15,10 @@ app(Schedule::class)->command('cleanup:guest-users')
     ->runInBackground()
     ->withoutOverlapping()
     ->appendOutputTo(storage_path('logs/scheduler.log'));
+
+// attachments GC: 毎日深夜にtempをクリーン
+app(Schedule::class)->command('attachments:gc --days=1')
+    ->dailyAt('03:10')
+    ->runInBackground()
+    ->withoutOverlapping()
+    ->appendOutputTo(storage_path('logs/scheduler.log'));

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -3,6 +3,11 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\TenantHomeController;
 use App\Http\Controllers\Auth\GuestLoginController;
+use App\Http\Controllers\AttachmentController;
+use App\Http\Controllers\ForumController;
+use App\Http\Controllers\PostController;
+use App\Http\Controllers\CommentController;
+use App\Http\Controllers\LikeController;
 
 // テナントドメイン限定のルートは、bootstrap/app.php 側の Route::domain() で
 // ミドルウェア（InitializeTenancyByDomain 等）を付与して読み込まれる前提。
@@ -15,3 +20,28 @@ Route::get('/guest/login', [TenantHomeController::class, 'index'])->name('guest.
 
 // 実行：ゲストで入る（中央には置かない）
 Route::middleware('guest')->get('/guest/user/login', [GuestLoginController::class, 'loginAsGuest'])->name('guest.user.login');
+
+// 認証配下のテナントルート（保存・表示のFSコンテキストを統一）
+Route::middleware(['auth'])->group(function () {
+    // 添付
+    Route::get('/attachments/{attachment}', [AttachmentController::class, 'show'])->name('attachments.show');
+    Route::delete('/attachments/{attachment}', [AttachmentController::class, 'destroy'])->name('attachments.destroy');
+
+    // フォーラム
+    Route::get('/forum', [ForumController::class, 'index'])->name('forum.index');
+
+    // 投稿
+    Route::post('/forum/post', [PostController::class, 'store'])->name('forum.store');
+    Route::delete('/forum/post/{id}', [PostController::class, 'destroy'])->name('forum.destroy');
+    Route::post('/forum/post/{post}/attachments', [PostController::class, 'addAttachments'])->name('forum.post.attachments.add');
+    Route::delete('/forum/post/{post}/attachments/{attachmentId}', [PostController::class, 'removeAttachment'])->name('forum.post.attachments.remove');
+
+    // いいね
+    Route::post('/like/toggle', [LikeController::class, 'toggleLike'])->name('like.toggle');
+
+    // コメント
+    Route::post('/forum/comment', [CommentController::class, 'store'])->name('comment.store');
+    Route::delete('/forum/comment/{id}', [CommentController::class, 'destroy'])->name('comment.destroy');
+    Route::post('/forum/comment/{comment}/attachments', [CommentController::class, 'addAttachments'])->name('forum.comment.attachments.add');
+    Route::delete('/forum/comment/{comment}/attachments/{attachmentId}', [CommentController::class, 'removeAttachment'])->name('forum.comment.attachments.remove');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,25 +35,8 @@ Route::middleware(['auth'])->group(function () {
     // ユーザーの所属ユニットのforum_idを取得（エンドポイント）
     Route::get('/user-forum-id', [UserController::class, 'getUserForumId']);
 
-    // フォーラム
-    Route::get('/forum', [ForumController::class, 'index'])->name('forum.index');
-
-    // 投稿
-    Route::post('/forum/post', [PostController::class, 'store'])->name('forum.store');
-    Route::delete('/forum/post/{id}', [PostController::class, 'destroy'])->name('forum.destroy');
-    Route::post('/forum/post/{post}/attachments', [PostController::class, 'addAttachments'])->name('forum.post.attachments.add');
-    Route::delete('/forum/post/{post}/attachments/{attachmentId}', [PostController::class, 'removeAttachment'])->name('forum.post.attachments.remove');
-    Route::post('/like/toggle', [LikeController::class, 'toggleLike'])->name('like.toggle');
-
-    // 返信
-    Route::post('/forum/comment', [CommentController::class, 'store'])->name('comment.store');
-    Route::delete('/forum/comment/{id}', [CommentController::class, 'destroy'])->name('comment.destroy');
-    Route::post('/forum/comment/{comment}/attachments', [CommentController::class, 'addAttachments'])->name('forum.comment.attachments.add');
-    Route::delete('/forum/comment/{comment}/attachments/{attachmentId}', [CommentController::class, 'removeAttachment'])->name('forum.comment.attachments.remove');
-
-    // 添付ファイル
-    Route::get('/attachments/{attachment}', [AttachmentController::class, 'show'])->name('attachments.show');
-    Route::delete('/attachments/{attachment}', [AttachmentController::class, 'destroy'])->name('attachments.destroy');
+    // NOTE: フォーラム/投稿/コメント/添付はテナントドメイン配下に移動（routes/tenant.php）
+    // web.php 側では定義しないことで、保存と表示のFSコンテキスト不一致を回避
 
     // ユーザー（職員）
     Route::resource('users', UserController::class);


### PR DESCRIPTION
### 目的

添付ファイルの保存・表示・削除における不整合（保存時と表示時のFS文脈不一致、失敗時のゴミ残り、上限不統一、旧データ欠損）を解消し、現場で安定して使える状態にする。

### 達成条件

- 新規アップロードが投稿（DBコミット）成功時のみ恒久保存される
- tempに残った一時ファイルは自動GCで削除される
- バックエンド/フロントで上限（10件/各10MB）が一致し、UIで過剰送信を抑止できる
- 旧データで中央に実体が残るものはself-healで自動修復（運用フラグでON/OFF）

### 実装の概要

- 一時保存→確定保存（フェーズ1）
  - AttachmentService: 新規アップロードは `public/temp/attachments/...` に保存し、`DB::afterCommit` で `public/attachments/...` へ move。コミット失敗・キャンセル時の恒久保存を防止
  - 投稿削除: PostService::deletePost で統一添付＋レガシーimgを物理削除
- GC（ガーベジコレクション）（フェーズ1）
  - 追加コマンド: `attachments:gc --days=1 --tenant= --dry-run`（tenant初期化の上で temp配下を削除）
  - スケジュール登録: 毎日 03:10 にGC実行（routes/console.php）
- 制約の統一（フェーズ2）
  - バックエンド: Post/Comment Requestで `files: array|max:10`、`files.*: mimes + max:10MB`
  - フロント: FileUpload.vue に `maxFiles=10`、超過時にUIで抑止
- ログの抑制（フェーズ2）
  - config/attachments.php に `debug_log`（ENV: ATTACHMENTS_DEBUG_LOG）を追加。情報系ログをフラグで抑制
- self-heal（オプション、フェーズ3先取り）
  - AttachmentController@show: tenant FSに無い場合、central FSから1回だけコピーして配信（ENV: ATTACHMENTS_SELF_HEAL=true）
  - centralにも無い場合は404のまま（安全側）。監査ログ（debug_log=true時）で追跡可能
- 付随
  - routes/tenant.php へforum/post/comment/attachments/likeを集約（FS文脈統一）。web.php側の同等ルートは撤去
  - .gitignore に `/storage/**` を追加して生成物の誤コミットを抑止
  - ドキュメント: `docs/attachments-ops.md` に Repair/GC/一時保存→確定保存/self-heal の運用を記載

### 対処したバグ

- 添付の保存/表示時のFS文脈不一致により特定画像が404になる問題
- 投稿削除後もストレージにファイルが残る問題
- ハッシュ重複最適化で「物理実体が無い旧レコード」を再利用し表示不可になる問題（新規は新規保存にフォールバック）

### 必要なかった実装

- 表示時に常にcentral→tenantへフォールバック配信する恒常モード：
  - 安全性（境界）と運用方針上、既定では採用を見送り。運用フラグ（ATTACHMENTS_SELF_HEAL）による任意ON/OFFで提供

### レビューしてほしいところ

- 一時保存→確定保存のフローと、DB::afterCommitのトランザクション境界（投稿失敗時にmoveされないこと）
- GCの実行条件とdry-runの挙動（誤削除防止）
- self-healの安全性（tenant() の初期化/終了の扱い、監査ログ）

### 不安に思っていること

- 旧データで central にも実体が無いもの（repair/missing）は再アップロードが必要。self-healでは救済不可
- 例外系のログ量（本番では ATTACHMENTS_DEBUG_LOG=false で抑制可能）

### 保留していること

- クリップボード貼付、進捗UI/キャンセル、A11y改善（別PRで対応）

