### PR TITLE
セキュリティテストスイート追加と危険コマンド遮断、テナント境界/サービス層の安全性強化

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,9 @@
         <testsuite name="Performance">
             <directory>tests/Performance</directory>
         </testsuite>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/tests/Security/DangerousOperationTest.php
+++ b/tests/Security/DangerousOperationTest.php
@@ -24,9 +24,7 @@ class DangerousOperationTest extends TestCase
         $this->assertSame(':memory:', env('DB_DATABASE'));
     }
 
-    /**
-     * @dataProvider dangerousCommands
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dangerousCommands')]
     public function test_dangerous_artisan_commands_are_blocked(string $command): void
     {
         $this->expectException(Exception::class);
@@ -46,4 +44,3 @@ class DangerousOperationTest extends TestCase
         ];
     }
 }
-

--- a/tests/Security/DangerousOperationTest.php
+++ b/tests/Security/DangerousOperationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Security;
+
+use Exception;
+use Tests\TestCase; // セキュリティ機構内蔵の基底クラス
+
+/**
+ * 危険な操作がテスト環境で実行できないことを検証する安全テスト
+ * - APP_ENV=testing の強制
+ * - SQLite + :memory: の強制
+ * - 破壊的artisanコマンドのブロック
+ */
+class DangerousOperationTest extends TestCase
+{
+    public function test_environment_is_testing(): void
+    {
+        $this->assertSame('testing', env('APP_ENV'));
+    }
+
+    public function test_database_is_sqlite_memory(): void
+    {
+        $this->assertSame('sqlite', env('DB_CONNECTION'));
+        $this->assertSame(':memory:', env('DB_DATABASE'));
+    }
+
+    /**
+     * @dataProvider dangerousCommands
+     */
+    public function test_dangerous_artisan_commands_are_blocked(string $command): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/危険なコマンド/');
+
+        // Tests\\TestCase::artisan を経由し、ブラックリストで例外が投げられることを検証
+        $this->artisan($command);
+    }
+
+    public static function dangerousCommands(): array
+    {
+        return [
+            ['migrate:fresh'],
+            ['migrate:reset'],
+            ['db:wipe'],
+            ['migrate:rollback'],
+        ];
+    }
+}
+

--- a/tests/Support/UserStub.php
+++ b/tests/Support/UserStub.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Support;
+
+class UserStub
+{
+    public int $id;
+    public int $tenant_id;
+    private bool $isAdmin;
+
+    public function __construct(int $id, int $tenantId, bool $isAdmin = false)
+    {
+        $this->id = $id;
+        $this->tenant_id = $tenantId;
+        $this->isAdmin = $isAdmin;
+    }
+
+    public function hasRole(string $role): bool
+    {
+        return $role === 'admin' && $this->isAdmin;
+    }
+}
+

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,19 @@ use Exception;
 
 abstract class TestCase extends BaseTestCase
 {
+    /**
+     * Laravelアプリケーションのブートストラップ
+     * 各テストで必要となるアプリケーションインスタンスを生成
+     */
+    public function createApplication()
+    {
+        $app = require __DIR__ . '/../bootstrap/app.php';
+
+        $app->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+        return $app;
+    }
+
     protected function setUp(): void
     {
         // 🚨 第1段階：環境チェック（絶対に破ってはいけない壁）

--- a/tests/Unit/PostServiceSecurityTest.php
+++ b/tests/Unit/PostServiceSecurityTest.php
@@ -7,6 +7,7 @@ use App\Models\Post;
 use App\Services\PostService;
 use App\Services\AttachmentService;
 use Illuminate\Support\Facades\Auth;
+use Tests\Support\UserStub;
 use Mockery;
 
 class PostServiceSecurityTest extends TestCase
@@ -31,11 +32,7 @@ class PostServiceSecurityTest extends TestCase
 
     public function test_can_delete_post_returns_true_for_owner(): void
     {
-        $user = new class {
-            public $id = 123;
-            public function hasRole($role) { return false; }
-        };
-        Auth::shouldReceive('user')->andReturn($user);
+        Auth::shouldReceive('user')->andReturn(new UserStub(123, 1, false));
 
         $post = new Post();
         $post->user_id = 123;
@@ -45,11 +42,7 @@ class PostServiceSecurityTest extends TestCase
 
     public function test_can_delete_post_returns_true_for_admin(): void
     {
-        $user = new class {
-            public $id = 999;
-            public function hasRole($role) { return $role === 'admin'; }
-        };
-        Auth::shouldReceive('user')->andReturn($user);
+        Auth::shouldReceive('user')->andReturn(new UserStub(999, 1, true));
 
         $post = new Post();
         $post->user_id = 123; // 別ユーザーの投稿
@@ -63,4 +56,3 @@ class PostServiceSecurityTest extends TestCase
         parent::tearDown();
     }
 }
-

--- a/tests/Unit/PostServiceSecurityTest.php
+++ b/tests/Unit/PostServiceSecurityTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Models\Post;
+use App\Services\PostService;
+use App\Services\AttachmentService;
+use Illuminate\Support\Facades\Auth;
+use Mockery;
+
+class PostServiceSecurityTest extends TestCase
+{
+    private PostService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new PostService(Mockery::mock(AttachmentService::class));
+    }
+
+    public function test_can_delete_post_returns_false_when_unauthenticated(): void
+    {
+        Auth::shouldReceive('user')->andReturn(null);
+
+        $post = new Post();
+        $post->user_id = 123;
+
+        $this->assertFalse($this->service->canDeletePost($post));
+    }
+
+    public function test_can_delete_post_returns_true_for_owner(): void
+    {
+        $user = new class {
+            public $id = 123;
+            public function hasRole($role) { return false; }
+        };
+        Auth::shouldReceive('user')->andReturn($user);
+
+        $post = new Post();
+        $post->user_id = 123;
+
+        $this->assertTrue($this->service->canDeletePost($post));
+    }
+
+    public function test_can_delete_post_returns_true_for_admin(): void
+    {
+        $user = new class {
+            public $id = 999;
+            public function hasRole($role) { return $role === 'admin'; }
+        };
+        Auth::shouldReceive('user')->andReturn($user);
+
+        $post = new Post();
+        $post->user_id = 123; // 別ユーザーの投稿
+
+        $this->assertTrue($this->service->canDeletePost($post));
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}
+

--- a/tests/Unit/TenantBoundaryCheckTest.php
+++ b/tests/Unit/TenantBoundaryCheckTest.php
@@ -6,6 +6,7 @@ use Tests\TestCase;
 use App\Traits\TenantBoundaryCheckTrait;
 use App\Exceptions\Custom\TenantViolationException;
 use Illuminate\Support\Facades\Auth;
+use Tests\Support\UserStub;
 use Illuminate\Database\Eloquent\Model;
 
 class TenantBoundaryCheckTest extends TestCase
@@ -76,11 +77,7 @@ class TenantBoundaryCheckTest extends TestCase
 
     private function mockAuthUser(int $id, int $tenantId): void
     {
-        $user = new class($id, $tenantId) {
-            public function __construct(public int $id, public int $tenant_id) {}
-        };
-
-        Auth::shouldReceive('user')->andReturn($user);
+        Auth::shouldReceive('user')->andReturn(new UserStub($id, $tenantId));
     }
 }
 
@@ -113,4 +110,3 @@ class DummyModel extends Model
         parent::__construct();
     }
 }
-

--- a/tests/Unit/TenantBoundaryCheckTest.php
+++ b/tests/Unit/TenantBoundaryCheckTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Traits\TenantBoundaryCheckTrait;
+use App\Exceptions\Custom\TenantViolationException;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Database\Eloquent\Model;
+
+class TenantBoundaryCheckTest extends TestCase
+{
+    private DummyChecker $checker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->checker = new DummyChecker();
+    }
+
+    public function test_validate_tenant_boundary_throws_on_mismatch(): void
+    {
+        $this->mockAuthUser(1, 10);
+
+        $resource = new DummyModel(1, 20);
+
+        $this->expectException(TenantViolationException::class);
+        $this->checker->check($resource);
+    }
+
+    public function test_validate_tenant_boundary_passes_on_match(): void
+    {
+        $this->mockAuthUser(2, 10);
+
+        $resource = new DummyModel(2, 10);
+
+        // 例外が投げられないことを確認
+        $this->checker->check($resource);
+        $this->assertTrue(true);
+    }
+
+    public function test_validate_multiple_tenant_boundaries_passes_all(): void
+    {
+        $this->mockAuthUser(3, 7);
+
+        $resources = [
+            new DummyModel(10, 7),
+            new DummyModel(11, 7),
+            new DummyModel(12, 7),
+        ];
+
+        $this->checker->checkMultiple($resources);
+        $this->assertTrue(true);
+    }
+
+    public function test_validate_related_resource_throws_on_missing_relation(): void
+    {
+        $this->mockAuthUser(4, 5);
+        $parent = new DummyModel(100, 5);
+        // 関連を設定しない（missing）
+
+        $this->expectException(TenantViolationException::class);
+        $this->checker->checkRelated($parent, 'child');
+    }
+
+    public function test_validate_related_resource_throws_on_mismatch(): void
+    {
+        $this->mockAuthUser(5, 5);
+        $parent = new DummyModel(200, 5);
+        $child = new DummyModel(201, 9); // テナント不一致
+        $parent->child = $child;
+
+        $this->expectException(TenantViolationException::class);
+        $this->checker->checkRelated($parent, 'child');
+    }
+
+    private function mockAuthUser(int $id, int $tenantId): void
+    {
+        $user = new class($id, $tenantId) {
+            public function __construct(public int $id, public int $tenant_id) {}
+        };
+
+        Auth::shouldReceive('user')->andReturn($user);
+    }
+}
+
+class DummyChecker
+{
+    use TenantBoundaryCheckTrait;
+
+    public function check(Model $resource, ?int $expectedTenantId = null): void
+    {
+        $this->validateTenantBoundary($resource, $expectedTenantId);
+    }
+
+    public function checkMultiple(array $resources): void
+    {
+        $this->validateMultipleTenantBoundaries($resources);
+    }
+
+    public function checkRelated(Model $resource, string $path): void
+    {
+        $this->validateRelatedResourceTenant($resource, $path);
+    }
+}
+
+class DummyModel extends Model
+{
+    public $timestamps = false;
+
+    public function __construct(public ?int $id = null, public ?int $tenant_id = null)
+    {
+        parent::__construct();
+    }
+}
+


### PR DESCRIPTION
### 目的
介護施設データ保護の最重要ルールに基づき、テスト実行時の破壊的操作を防ぎつつ、マルチテナント要件（tenant_idによる境界）とサービス層のセキュリティを強化するため。

### 達成条件
- APP_ENV=testing + SQLite :memory: 前提でセキュリティスイートがパスすること
- 危険なArtisanコマンド（migrate:fresh/reset、db:wipe、rollback）がテストから実行不能であること
- phpunit に Security スイートが組み込まれていること
- テナント境界/所有権の重要パスに対するユニットテストが追加されていること

### 実装の概要
- 追加: `tests/Security/DangerousOperationTest.php`
  - APP_ENV/DB接続の安全性検証と、破壊的Artisanコマンドのブロック検証
- 追加: `tests/Unit/TenantBoundaryCheckTest.php`
  - `TenantBoundaryCheckTrait` の境界チェック、関連リソース欠如、複数一括検証を網羅（AuthをモックしDB未依存で安全）
- 追加: `tests/Unit/PostServiceSecurityTest.php`
  - `canDeletePost` の未認証/所有者/管理者パスを検証（Authモック）
- 修正: `app/Traits/TenantBoundaryCheckTrait.php`
  - 例外生成の引数型不整合を修正（`TenantViolationException` の新シグネチャ準拠）
  - 関連欠如・一括検証時の例外メッセージを安全に構築（代表ID付与など）
- 更新: `phpunit.xml` に Security スイートを追加
- 更新: `tests/TestCase.php` に Laravel ブートストラップ（createApplication）を明示
- 追加: `docs/testing-security.md`（安全なテスト実行手順）

### 対処したバグ
- `TenantBoundaryCheckTrait` が `TenantViolationException` を配列引数で生成していた箇所を修正（型エラー回避・一貫したログ文脈）

### 必要なかった実装
- RefreshDatabaseトレイトを用いるテスト: セキュリティポリシー（DB破壊リスク）に反するため採用を検討したが、セーフティネットと方針により結果的に見送り
- テスト起動時の自動マイグレーション: APP_ENV=testingでのメモリDB運用と危険操作禁止方針により見送り（必要時は `runSafeMigrations` を個別に利用）
- 実DBを用いた関連整合性テスト: 単体はダミーモデル/モックで十分に検証可能なため見送り（統合は別途）

### レビューしてほしいところ
- `TenantBoundaryCheckTrait` の例外生成変更が既存呼び出しに対して後方互換であるか
- Security スイートの phpunit 組み込み位置・命名の妥当性
- PostService のAuthモック（`canDeletePost`）アプローチの許容範囲
- ドキュメント配置（`docs/testing-security.md`）の適切性

### 不安に思っていること
- PHPUnit 12 での DocComment メタデータ非推奨に関する警告（今後属性へ移行予定）
- CI上での `APP_ENV=testing` / SQLite :memory: 強制の徹底（別PRで設定化提案）

### 保留していること
- ForumService のセキュリティパス（テナント境界/N+1/変換結果）の詳細テスト追加
- CIの環境強制（APP_ENV/DB）とPest実行統一