### PR TITLE
feature/guest-domain-env: 本番のユーザー削除不具合の原因となるゲストドメイン設定を.env管理へ移行

### DIFF
--- a/docs/guest-domain-config.md
+++ b/docs/guest-domain-config.md
@@ -1,0 +1,41 @@
+# ゲストドメイン設定の環境変数化について
+
+本ドキュメントは、ゲストドメイン設定をコード直書きから `.env` に移行する背景と運用手順をまとめたものです。
+
+## 背景（不具合）
+- 本番環境で管理者がユーザーを削除できない事象があり、設定値の整合性（ゲストドメイン）が環境ごとに食い違う可能性がありました。
+- 環境依存値を `config/guest.php` に直書きすると、デプロイのたびに上書きや差分が発生し、挙動の不一致や混乱の原因になります。
+
+## 対応方針
+- 12factor/Laravelの原則に従い、環境依存値は `.env` で切り替えます。
+- `config/guest.php` は汎用デフォルト値のみを保持し、実値は `GUEST_DOMAIN_*` 環境変数から解決します。
+
+## 必要な環境変数
+- 本番: `.env.production`
+
+```
+GUEST_DOMAIN_PRODUCTION=guestdemo.communi-care.jp
+```
+
+必要に応じて以下も利用可能です:
+
+```
+GUEST_DOMAIN_LOCAL=guestdemo.localhost
+GUEST_DOMAIN_STAGING=guestdemo.staging.example.com
+GUEST_PROTOCOL=https   # 省略時: localはhttp、それ以外はhttps
+```
+
+## 反映手順
+1. `.env.production` を更新
+2. 設定キャッシュを再生成
+
+```
+php artisan optimize:clear
+php artisan config:cache
+```
+
+## 期待効果
+- デプロイ時の差分がなくなり、環境ごとの設定の一貫性を維持
+- 本番・ステージング・ローカルで安全にドメインを切替可能
+- GitHub上のコードと本番サーバの状態が乖離しにくく、保守性が向上
+

--- a/docs/guest-domain-config.md
+++ b/docs/guest-domain-config.md
@@ -7,7 +7,7 @@
 - 環境依存値を `config/guest.php` に直書きすると、デプロイのたびに上書きや差分が発生し、挙動の不一致や混乱の原因になります。
 
 ## 対応方針
-- 12factor/Laravelの原則に従い、環境依存値は `.env` で切り替えます。
+- 12factor/Laravelの原則（[12‑factor app: Config](https://12factor.net/config)）に従い、環境依存値は `.env` で切り替えます。
 - `config/guest.php` は汎用デフォルト値のみを保持し、実値は `GUEST_DOMAIN_*` 環境変数から解決します。
 
 ## 必要な環境変数
@@ -38,4 +38,3 @@ php artisan config:cache
 - デプロイ時の差分がなくなり、環境ごとの設定の一貫性を維持
 - 本番・ステージング・ローカルで安全にドメインを切替可能
 - GitHub上のコードと本番サーバの状態が乖離しにくく、保守性が向上
-


### PR DESCRIPTION
### 目的
本番環境で管理者がユーザーを削除できない問題の解消に向け、根本要因の一つである「ゲストドメイン設定のコード直書き」を排し、環境変数による切替に移行します（12factor/Laravel原則）。

### 達成条件
- 環境依存のゲストドメイン設定を `.env` で切替可能
- `config/guest.php` は汎用デフォルトのみを保持（本番値は `.env.production` で設定）
- 反映手順に従い、デプロイ毎の設定ズレが発生しない

### 実装の概要
- `config/guest.php` の production 既定値を汎用値（`guestdemo.example.com`）に整理し、実値は環境変数から解決
- `.env.production` に `GUEST_DOMAIN_PRODUCTION=guestdemo.communi-care.jp` を追加
- ドキュメント `docs/guest-domain-config.md` を追加（背景、必要変数、反映手順を明記）

### 対処したバグ
- 本番で設定差分が生じることでユーザー削除動作に影響しうる問題の温床を排除

### 必要なかった実装
- 「config/guest.php へ本番値の直書き」は、環境差分・保守性低下のため採用を検討したが、12factor原則に反するため結果的に削除（採用見送り）とし、`.env` 管理に統一

### レビューしてほしいところ
- 環境変数の命名と解決順序（`GUEST_DOMAIN_*`, `GUEST_PROTOCOL`）が既存コードと整合しているか
- 運用手順（optimize:clear, config:cache）の手戻り防止に十分か

### 不安に思っていること
- 既存サーバで `GUEST_DOMAIN_PRODUCTION` 未設定時のフォールバック（汎用値で問題ないか）

### 保留していること
- スキーム込みURLの一元管理（必要であれば `GUEST_BASE_URL` 等の導入を別PRで検討）