### PR TITLE
テナントスコープによりattachmentsのNULL化が効かない問題を修正

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -155,7 +155,7 @@ public function updateIcon(UserIconUpdateRequest $request)
         // 削除が失敗しないよう、参照をNULLへ更新（先にコミット）
         try {
             // Tenancyのグローバルスコープを回避しつつ、同一テナントに絞ってNULL化
-            Attachment::withoutGlobalScopes()
+            Attachment::withoutGlobalScope(\Stancl\Tenancy\Database\TenantScope::class)
                 ->where('tenant_id', $user->tenant_id)
                 ->where('uploaded_by', $user->id)
                 ->update(['uploaded_by' => null]);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -154,7 +154,11 @@ public function updateIcon(UserIconUpdateRequest $request)
         // 防御的対策: 外部キー制約（attachments.uploaded_by -> users.id）で
         // 削除が失敗しないよう、参照をNULLへ更新（先にコミット）
         try {
-            Attachment::where('uploaded_by', $user->id)->update(['uploaded_by' => null]);
+            // Tenancyのグローバルスコープを回避しつつ、同一テナントに絞ってNULL化
+            Attachment::withoutGlobalScopes()
+                ->where('tenant_id', $user->tenant_id)
+                ->where('uploaded_by', $user->id)
+                ->update(['uploaded_by' => null]);
         } catch (\Throwable $e) {
             Log::warning('Failed to nullify attachments.uploaded_by before user deletion', [
                 'user_id' => $user->id,


### PR DESCRIPTION
### 目的
本番環境で管理者によるユーザー削除が失敗するケースを解消する（attachments.uploaded_by のFK衝突回避が、Tenancyのグローバルスコープにより効かない可能性があるため）。

### 実装の概要
- `UserController@destroy`
  - `Attachment::withoutGlobalScopes()->where('tenant_id', $user->tenant_id)->where('uploaded_by', $user->id)->update(['uploaded_by' => null])` に変更
  - Tenancyのグローバルスコープが未初期化の場合でも、同一テナントのレコードを確実にNULL化

### 達成条件
- 同一テナントの管理者が、添付のあるユーザーを削除しても500にならない
- `attachments.uploaded_by` はNULLに更新される

### レビューしてほしいところ
- Tenancy初期化有無に依存せず、NULL化が漏れなく適用されること
- 既存のFK（ON DELETE SET NULL）と併用時の整合性

### 不安に思っていること
- マルチテナントの他箇所（別コントローラやサービス）で同様パターンがないか（追って横展開を検討）

### 保留していること
- ユーザーのアイコン等、Userをattachableとする添付の物理削除ポリシー（別PRで検討）