### PR TITLE
hasRole未定義エラーを回避するため管理者判定をrolesクエリに変更

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -139,17 +139,11 @@ public function updateIcon(UserIconUpdateRequest $request)
     {
         $currentUser = Auth::user();
 
-        // 権限チェック: 管理者のみ（IDE/環境差異で hasRole が未定義と判定されるケースを回避）
-        $hasAdminRole = false;
-        if ($currentUser) {
-            $hasAdminRole = User::whereKey($currentUser->id)
-                ->whereHas('roles', function ($q) {
-                    $q->where('name', 'admin')
-                      ->where('guard_name', 'web');
-                })
-                ->exists();
-        }
-        if (!$hasAdminRole) {
+        // 権限チェック: 管理者のみ（モデルインスタンスのrolesリレーションで判定）
+        if (!$currentUser || !$currentUser->roles()
+                ->where('name', 'admin')
+                ->where('guard_name', 'web')
+                ->exists()) {
             abort(403, 'Unauthorized');
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -144,7 +144,8 @@ public function updateIcon(UserIconUpdateRequest $request)
         if ($currentUser) {
             $hasAdminRole = User::whereKey($currentUser->id)
                 ->whereHas('roles', function ($q) {
-                    $q->where('name', 'admin');
+                    $q->where('name', 'admin')
+                      ->where('guard_name', 'web');
                 })
                 ->exists();
         }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -139,8 +139,16 @@ public function updateIcon(UserIconUpdateRequest $request)
     {
         $currentUser = Auth::user();
 
-        // 権限チェック: 管理者のみ
-        if (!$currentUser || !$currentUser->hasRole('admin')) {
+        // 権限チェック: 管理者のみ（IDE/環境差異で hasRole が未定義と判定されるケースを回避）
+        $hasAdminRole = false;
+        if ($currentUser) {
+            $hasAdminRole = User::whereKey($currentUser->id)
+                ->whereHas('roles', function ($q) {
+                    $q->where('name', 'admin');
+                })
+                ->exists();
+        }
+        if (!$hasAdminRole) {
             abort(403, 'Unauthorized');
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -139,11 +139,16 @@ public function updateIcon(UserIconUpdateRequest $request)
     {
         $currentUser = Auth::user();
 
-        // 権限チェック: 管理者のみ（モデルインスタンスのrolesリレーションで判定）
-        if (!$currentUser || !$currentUser->roles()
-                ->where('name', 'admin')
-                ->where('guard_name', 'web')
-                ->exists()) {
+        // 権限チェック: 管理者のみ（hasRole/roles()を直接呼ばず、whereHasで互換性を担保）
+        if (
+            !$currentUser ||
+            !User::whereKey($currentUser->id)
+                ->whereHas('roles', function ($q) {
+                    $q->where('name', 'admin')
+                      ->where('guard_name', 'web');
+                })
+                ->exists()
+        ) {
             abort(403, 'Unauthorized');
         }
 


### PR DESCRIPTION
### 目的
本番/静的解析環境で `Undefined method 'hasRole'.` が発生し得るため、UserController@destroy の管理者判定から `hasRole('admin')` を排し、ロールの存在をクエリで判定する方式に置き換えます。

### 実装の概要
- `Auth::user()->hasRole('admin')` → `User::whereKey(id)->whereHas('roles', name='admin')->exists()` に変更
- SpatieのHasRolesトレイトの有無に依存せず、Eloquentの関連で安全に判定

### 達成条件
- 管理者のみユーザー削除可能の仕様を維持
- `Undefined method 'hasRole'` 警告/エラーが発生しない

### 影響範囲
- `UserController@destroy` のみ（最小変更）
- 既存のテナント境界チェックや attachments.uploaded_by NULL 化処理には影響なし

### レビューしてほしいところ
- クエリベースの管理者判定が期待どおり動作すること
- マルチテナント仕様的な懸念点がないこと（削除対象とのテナント一致は既にチェック済み）

### 不安に思っていること
- 他箇所に `hasRole()` 直接呼び出しが残っていないか（必要なら別PRで横展開）

### 保留していること
- index() での `User::role('admin')` の例外安全化（別PRで `whereHas()` 置換を検討）