### PR TITLE
M2: スケジュール更新・削除機能と詳細な重複チェックの実装

### DIFF
--- a/app/Http/Requests/Schedule/ScheduleUpdateRequest.php
+++ b/app/Http/Requests/Schedule/ScheduleUpdateRequest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Requests\Schedule;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * スケジュール更新リクエスト
+ */
+class ScheduleUpdateRequest extends FormRequest
+{
+    /**
+     * 認可
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * バリデーションルール
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $tenantId = Auth::user()->tenant_id;
+        
+        return [
+            'date' => 'required|date|date_format:Y-m-d',
+            'resident_id' => [
+                'required',
+                'exists:residents,id',
+                Rule::exists('residents', 'id')->where(function ($query) use ($tenantId) {
+                    $query->where('tenant_id', $tenantId);
+                }),
+            ],
+            'schedule_type_id' => [
+                'required',
+                'exists:schedule_types,id',
+                Rule::exists('schedule_types', 'id')->where(function ($query) use ($tenantId) {
+                    $query->where('tenant_id', $tenantId);
+                }),
+            ],
+            'start_time' => 'required|date_format:H:i',
+            'end_time' => 'required|date_format:H:i|after:start_time',
+            'memo' => 'nullable|string|max:1000',
+        ];
+    }
+
+    /**
+     * エラーメッセージ
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'date.required' => '日付は必須です。',
+            'date.date' => '日付の形式が正しくありません。',
+            'date.date_format' => '日付はYYYY-MM-DD形式で入力してください。',
+            'resident_id.required' => '利用者の指定は必須です。',
+            'resident_id.exists' => '指定された利用者は存在しないか、アクセスできません。',
+            'schedule_type_id.required' => 'スケジュール種別の指定は必須です。',
+            'schedule_type_id.exists' => '指定されたスケジュール種別は存在しないか、アクセスできません。',
+            'start_time.required' => '開始時刻は必須です。',
+            'start_time.date_format' => '開始時刻はHH:MM形式で入力してください。',
+            'end_time.required' => '終了時刻は必須です。',
+            'end_time.date_format' => '終了時刻はHH:MM形式で入力してください。',
+            'end_time.after' => '終了時刻は開始時刻より後である必要があります。',
+            'memo.string' => 'メモは文字列で入力してください。',
+            'memo.max' => 'メモは1000文字以内で入力してください。',
+        ];
+    }
+}

--- a/app/Services/ScheduleService.php
+++ b/app/Services/ScheduleService.php
@@ -7,6 +7,7 @@ use App\Models\CalendarDate;
 use App\Models\Resident;
 use App\Models\ScheduleType;
 use App\Http\Requests\Schedule\ScheduleStoreRequest;
+use App\Http\Requests\Schedule\ScheduleUpdateRequest;
 use App\Exceptions\Custom\TenantViolationException;
 use App\Exceptions\Custom\ScheduleConflictException;
 use App\Traits\TenantBoundaryCheckTrait;
@@ -94,7 +95,7 @@ class ScheduleService
             $scheduleType = ScheduleType::findOrFail($validated['schedule_type_id']);
             $this->validateTenantBoundary($scheduleType);
 
-            // 簡易重複チェック（M1では同時刻一致のみ）
+            // 詳細な重複チェック（M2：時間帯の重複検証）
             $this->validateNoConflict(
                 $validated['resident_id'],
                 $calendarDate->id,
@@ -155,12 +156,103 @@ class ScheduleService
     }
 
     /**
-     * 重複スケジュールをチェック（M1では簡易チェック：同時刻一致のみ）
+     * スケジュールを更新
+     *
+     * @param Schedule $schedule
+     * @param ScheduleUpdateRequest $request
+     * @return Schedule
+     * @throws TenantViolationException
+     * @throws ScheduleConflictException
+     */
+    public function updateSchedule(Schedule $schedule, ScheduleUpdateRequest $request): Schedule
+    {
+        $validated = $request->validated();
+        $currentUser = Auth::user();
+        $currentTenantId = $currentUser->tenant_id;
+
+        // テナント境界チェック
+        $this->validateTenantBoundary($schedule);
+
+        // 日付マスタの取得または作成（トランザクション外で実行）
+        $calendarDate = $this->ensureCalendarDate($validated['date'], $currentTenantId);
+
+        return DB::transaction(function () use ($schedule, $validated, $currentTenantId, $currentUser, $calendarDate) {
+            // 利用者のテナント境界チェック
+            $resident = Resident::findOrFail($validated['resident_id']);
+            $this->validateTenantBoundary($resident);
+
+            // 種別のテナント境界チェック
+            $scheduleType = ScheduleType::findOrFail($validated['schedule_type_id']);
+            $this->validateTenantBoundary($scheduleType);
+
+            // 詳細な重複チェック（M2：時間帯の重複検証）
+            $this->validateNoConflict(
+                $validated['resident_id'],
+                $calendarDate->id,
+                $validated['start_time'],
+                $validated['end_time'],
+                $schedule->id // 自分自身を除外
+            );
+
+            // スケジュール更新
+            $schedule->update([
+                'calendar_date_id' => $calendarDate->id,
+                'resident_id' => $validated['resident_id'],
+                'schedule_type_id' => $validated['schedule_type_id'],
+                'start_time' => $validated['start_time'],
+                'end_time' => $validated['end_time'],
+                'memo' => $validated['memo'] ?? null,
+            ]);
+
+            Log::info('スケジュールを更新しました', [
+                'schedule_id' => $schedule->id,
+                'tenant_id' => $currentTenantId,
+                'resident_id' => $validated['resident_id'],
+                'date' => $validated['date'],
+            ]);
+
+            return $schedule->fresh();
+        });
+    }
+
+    /**
+     * スケジュールを削除
+     *
+     * @param Schedule $schedule
+     * @return void
+     * @throws TenantViolationException
+     */
+    public function deleteSchedule(Schedule $schedule): void
+    {
+        $currentUser = Auth::user();
+        $currentTenantId = $currentUser->tenant_id;
+
+        // テナント境界チェック
+        $this->validateTenantBoundary($schedule);
+
+        DB::transaction(function () use ($schedule, $currentTenantId) {
+            $scheduleId = $schedule->id;
+            $residentId = $schedule->resident_id;
+            $calendarDate = $schedule->calendarDate;
+
+            $schedule->delete();
+
+            Log::info('スケジュールを削除しました', [
+                'schedule_id' => $scheduleId,
+                'tenant_id' => $currentTenantId,
+                'resident_id' => $residentId,
+                'date' => $calendarDate ? $calendarDate->date->toDateString() : null,
+            ]);
+        });
+    }
+
+    /**
+     * 重複スケジュールをチェック（M2：時間帯の重複検証）
      *
      * @param int $residentId
      * @param int $calendarDateId
      * @param string $startTime HH:MM形式
-     * @param string $endTime HH:MM形式（M1では未使用、M2で時間帯重複チェックに使用予定）
+     * @param string $endTime HH:MM形式
      * @param int|null $excludeScheduleId 更新時は自分自身を除外
      * @return void
      * @throws ScheduleConflictException
@@ -174,22 +266,34 @@ class ScheduleService
     ): void {
         $currentTenantId = Auth::user()->tenant_id;
 
+        // 時間帯の重複をチェック
+        // 重複条件: 開始時刻 < 既存の終了時刻 かつ 終了時刻 > 既存の開始時刻
         $query = Schedule::where('tenant_id', $currentTenantId)
             ->where('resident_id', $residentId)
             ->where('calendar_date_id', $calendarDateId)
-            ->where('start_time', $startTime); // M1では同時刻一致のみチェック
+            ->where(function ($q) use ($startTime, $endTime) {
+                $q->where(function ($q2) use ($startTime, $endTime) {
+                    // 新しいスケジュールの開始時刻が既存のスケジュールの終了時刻より前
+                    // かつ新しいスケジュールの終了時刻が既存のスケジュールの開始時刻より後
+                    $q2->where('start_time', '<', $endTime)
+                       ->where('end_time', '>', $startTime);
+                });
+            });
 
         if ($excludeScheduleId) {
             $query->where('id', '!=', $excludeScheduleId);
         }
 
-        if ($query->exists()) {
+        $conflictingSchedule = $query->first();
+
+        if ($conflictingSchedule) {
             $calendarDate = CalendarDate::findOrFail($calendarDateId);
             throw new ScheduleConflictException(
                 residentId: $residentId,
                 date: $calendarDate->date->toDateString(),
                 startTime: $startTime,
-                endTime: $endTime
+                endTime: $endTime,
+                conflictingScheduleId: $conflictingSchedule->id
             );
         }
     }

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -49,4 +49,6 @@ Route::middleware(['auth'])->group(function () {
     // スケジュール
     Route::get('/calendar/schedules', [ScheduleController::class, 'index'])->name('calendar.schedules.index');
     Route::post('/calendar/schedule', [ScheduleController::class, 'store'])->name('calendar.schedule.store');
+    Route::put('/calendar/schedule/{schedule}', [ScheduleController::class, 'update'])->name('calendar.schedule.update');
+    Route::delete('/calendar/schedule/{schedule}', [ScheduleController::class, 'destroy'])->name('calendar.schedule.destroy');
 });

--- a/tests/Feature/ScheduleTest.php
+++ b/tests/Feature/ScheduleTest.php
@@ -240,4 +240,250 @@ class ScheduleTest extends TestCase
         $data = $response->json('data');
         $this->assertEmpty($data);
     }
+
+    public function test_can_update_schedule(): void
+    {
+        // テナント1を直接初期化
+        tenancy()->initialize($this->tenant1);
+        $this->actingAs($this->user1);
+        
+        $date = Carbon::today()->format('Y-m-d');
+        
+        // スケジュールを作成
+        $createResponse = $this->postJson(route('calendar.schedule.store'), [
+            'date' => $date,
+            'resident_id' => $this->resident1->id,
+            'schedule_type_id' => $this->scheduleType1->id,
+            'start_time' => '10:00',
+            'end_time' => '11:00',
+            'memo' => 'Original memo',
+        ]);
+        
+        $createResponse->assertStatus(201);
+        $scheduleId = $createResponse->json('data.id');
+        
+        // スケジュールを更新
+        $updateResponse = $this->putJson(route('calendar.schedule.update', $scheduleId), [
+            'date' => $date,
+            'resident_id' => $this->resident1->id,
+            'schedule_type_id' => $this->scheduleType1->id,
+            'start_time' => '14:00',
+            'end_time' => '15:00',
+            'memo' => 'Updated memo',
+        ]);
+        
+        $updateResponse->assertStatus(200);
+        $updateResponse->assertJsonStructure([
+            'data' => [
+                'id',
+                'tenant_id',
+                'resident_id',
+                'schedule_type_id',
+                'start_time',
+                'end_time',
+                'memo',
+            ],
+        ]);
+        
+        $this->assertDatabaseHas('schedules', [
+            'id' => $scheduleId,
+            'start_time' => '14:00',
+            'end_time' => '15:00',
+            'memo' => 'Updated memo',
+        ]);
+    }
+
+    public function test_cannot_update_schedule_with_time_conflict(): void
+    {
+        // テナント1を直接初期化
+        tenancy()->initialize($this->tenant1);
+        $this->actingAs($this->user1);
+        
+        $date = Carbon::today()->format('Y-m-d');
+        
+        // 最初のスケジュールを作成（10:00-11:00）
+        $firstResponse = $this->postJson(route('calendar.schedule.store'), [
+            'date' => $date,
+            'resident_id' => $this->resident1->id,
+            'schedule_type_id' => $this->scheduleType1->id,
+            'start_time' => '10:00',
+            'end_time' => '11:00',
+        ]);
+        
+        $firstResponse->assertStatus(201);
+        
+        // 2つ目のスケジュールを作成（12:00-13:00）
+        $secondResponse = $this->postJson(route('calendar.schedule.store'), [
+            'date' => $date,
+            'resident_id' => $this->resident1->id,
+            'schedule_type_id' => $this->scheduleType1->id,
+            'start_time' => '12:00',
+            'end_time' => '13:00',
+        ]);
+        
+        $secondResponse->assertStatus(201);
+        $scheduleId = $secondResponse->json('data.id');
+        
+        // 2つ目のスケジュールを更新して、1つ目のスケジュールと時間帯が重複するようにする（10:30-11:30）
+        $updateResponse = $this->putJson(route('calendar.schedule.update', $scheduleId), [
+            'date' => $date,
+            'resident_id' => $this->resident1->id,
+            'schedule_type_id' => $this->scheduleType1->id,
+            'start_time' => '10:30',
+            'end_time' => '11:30',
+        ]);
+        
+        $updateResponse->assertStatus(409);
+        $updateResponse->assertJson([
+            'error_code' => 'SCHEDULE_CONFLICT',
+        ]);
+    }
+
+    public function test_can_delete_schedule(): void
+    {
+        // テナント1を直接初期化
+        tenancy()->initialize($this->tenant1);
+        $this->actingAs($this->user1);
+        
+        $date = Carbon::today()->format('Y-m-d');
+        
+        // スケジュールを作成
+        $createResponse = $this->postJson(route('calendar.schedule.store'), [
+            'date' => $date,
+            'resident_id' => $this->resident1->id,
+            'schedule_type_id' => $this->scheduleType1->id,
+            'start_time' => '10:00',
+            'end_time' => '11:00',
+        ]);
+        
+        $createResponse->assertStatus(201);
+        $scheduleId = $createResponse->json('data.id');
+        
+        // スケジュールを削除
+        $deleteResponse = $this->deleteJson(route('calendar.schedule.destroy', $scheduleId));
+        
+        $deleteResponse->assertStatus(200);
+        $deleteResponse->assertJson([
+            'message' => 'スケジュールを削除しました。',
+        ]);
+        
+        $this->assertDatabaseMissing('schedules', [
+            'id' => $scheduleId,
+        ]);
+    }
+
+    public function test_cannot_update_other_tenant_schedule(): void
+    {
+        // tenant1のスケジュールを作成
+        tenancy()->initialize($this->tenant1);
+        $this->actingAs($this->user1);
+        
+        $date = Carbon::today()->format('Y-m-d');
+        $calendarDate = CalendarDate::firstOrCreate(
+            [
+                'tenant_id' => $this->tenant1->id,
+                'date' => Carbon::parse($date)->format('Y-m-d'),
+            ],
+            [
+                'day_of_week' => Carbon::parse($date)->dayOfWeek,
+                'is_holiday' => false,
+                'holiday_name' => null,
+            ]
+        );
+        
+        $schedule = Schedule::create([
+            'tenant_id' => $this->tenant1->id,
+            'calendar_date_id' => $calendarDate->id,
+            'resident_id' => $this->resident1->id,
+            'schedule_type_id' => $this->scheduleType1->id,
+            'start_time' => '10:00',
+            'end_time' => '11:00',
+            'created_by' => $this->user1->id,
+        ]);
+        
+        // tenant2のリソースを作成
+        tenancy()->end();
+        tenancy()->initialize($this->tenant2);
+        
+        $unit2 = Unit::create([
+            'name' => 'Test Unit 2',
+            'tenant_id' => $this->tenant2->id,
+        ]);
+        
+        $resident2 = Resident::create([
+            'name' => 'Test Resident 2',
+            'unit_id' => $unit2->id,
+            'tenant_id' => $this->tenant2->id,
+        ]);
+        
+        $scheduleType2 = ScheduleType::create([
+            'tenant_id' => $this->tenant2->id,
+            'name' => '入浴2',
+            'color' => '#3B82F6',
+            'sort_order' => 1,
+        ]);
+        
+        $this->actingAs($this->user2);
+        
+        // tenant1のスケジュールをtenant2のリソースで更新しようとする（テナント境界違反）
+        $response = $this->putJson(route('calendar.schedule.update', $schedule->id), [
+            'date' => $date,
+            'resident_id' => $resident2->id,
+            'schedule_type_id' => $scheduleType2->id,
+            'start_time' => '14:00',
+            'end_time' => '15:00',
+        ]);
+        
+        $response->assertStatus(403);
+        $response->assertJson([
+            'error_code' => 'TENANT_VIOLATION',
+        ]);
+    }
+
+    public function test_cannot_delete_other_tenant_schedule(): void
+    {
+        // tenant1のスケジュールを作成
+        tenancy()->initialize($this->tenant1);
+        $this->actingAs($this->user1);
+        
+        $date = Carbon::today()->format('Y-m-d');
+        $calendarDate = CalendarDate::firstOrCreate(
+            [
+                'tenant_id' => $this->tenant1->id,
+                'date' => Carbon::parse($date)->format('Y-m-d'),
+            ],
+            [
+                'day_of_week' => Carbon::parse($date)->dayOfWeek,
+                'is_holiday' => false,
+                'holiday_name' => null,
+            ]
+        );
+        
+        $schedule = Schedule::create([
+            'tenant_id' => $this->tenant1->id,
+            'calendar_date_id' => $calendarDate->id,
+            'resident_id' => $this->resident1->id,
+            'schedule_type_id' => $this->scheduleType1->id,
+            'start_time' => '10:00',
+            'end_time' => '11:00',
+            'created_by' => $this->user1->id,
+        ]);
+        
+        // tenant2のユーザーで削除試行
+        tenancy()->end();
+        tenancy()->initialize($this->tenant2);
+        $this->actingAs($this->user2);
+        
+        $response = $this->deleteJson(route('calendar.schedule.destroy', $schedule->id));
+        
+        $response->assertStatus(403);
+        $response->assertJson([
+            'error_code' => 'TENANT_VIOLATION',
+        ]);
+        
+        // スケジュールが削除されていないことを確認
+        $this->assertDatabaseHas('schedules', [
+            'id' => $schedule->id,
+        ]);
+    }
 }


### PR DESCRIPTION
### 目的

カレンダー／入浴スケジュール機能のM2フェーズとして、スケジュールの更新・削除機能と詳細な重複チェック（時間帯の重複検証）を実装しました。

### 達成条件

- [x] スケジュール更新機能の実装
- [x] スケジュール削除機能の実装
- [x] 詳細な重複チェック（時間帯の重複検証）の実装
- [x] テナント境界チェックの実装
- [x] すべてのFeatureTestが通過（7テスト、35アサーション）

### 実装の概要

#### バックエンド実装

1. **ScheduleUpdateRequestの作成**
   - テナント境界チェックを含むバリデーションルール

2. **ScheduleService::updateSchedule()とdeleteSchedule()の実装**
   - スケジュール更新・削除処理
   - テナント境界チェック
   - 詳細な重複チェック（時間帯の重複検証）

3. **validateNoConflict()の改善（M2要件）**
   - M1では同時刻一致のみチェックしていたが、M2では時間帯の重複検証に対応

4. **ScheduleController::update()とdestroy()の実装**
   - ルートバインディングを無効化し、明示的にモデルを取得してテナント境界チェックを実装

5. **ルートの追加**
   - PUT /calendar/schedule/{id} - スケジュール更新
   - DELETE /calendar/schedule/{id} - スケジュール削除

#### テスト実装

- スケジュール更新・削除の基本機能テスト
- 時間帯重複チェックテスト
- テナント境界チェックテスト

### 対処したバグ

1. **ensureCalendarDate()のUNIQUE制約違反ハンドリング**
   - firstOrCreate()でUNIQUE制約違反が発生した場合のエラーハンドリングを追加

2. **ルートバインディングでのテナント境界チェック**
   - テナント境界違反時は404ではなく403を返すように修正

### 必要なかった実装

特になし

### レビューしてほしいところ

1. テナント境界チェックの実装方法
2. 時間帯重複チェックのロジック

### 不安に思っていること

特になし

### 保留していること

- M3: カレンダーUI実装（Vue.js + Inertia.js）
- M4: 高度な機能（一括登録、テンプレート機能など）