### PR TITLE
fix: CalendarControllerでresident/scheduleType/calendarDateのnullチェックを追加

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -48,6 +48,11 @@ class CalendarController extends Controller
 
         // FullCalendar用のイベント形式に変換
         $events = $schedules->map(function ($schedule) {
+            // リレーションがnullの場合はスキップ
+            if (!$schedule->resident || !$schedule->scheduleType || !$schedule->calendarDate) {
+                return null;
+            }
+
             // Carbonを使用してISO 8601形式の日時文字列を生成
             $startDateTime = Carbon::parse($schedule->calendarDate->date->format('Y-m-d') . ' ' . $schedule->start_time);
             $endDateTime = Carbon::parse($schedule->calendarDate->date->format('Y-m-d') . ' ' . $schedule->end_time);
@@ -67,7 +72,7 @@ class CalendarController extends Controller
                     'memo' => $schedule->memo,
                 ],
             ];
-        });
+        })->filter(); // nullの要素を除外
 
         // 利用者一覧を取得
         $residents = Resident::where('tenant_id', $currentTenantId)


### PR DESCRIPTION
## 問題
削除済みの利用者やスケジュール種別を参照しているスケジュールがある場合、`Attempt to read property "name" on null`エラーが発生していました。

## 修正内容
- `resident`、`scheduleType`、`calendarDate`のリレーションがnullの場合をチェック
- nullの場合はnullを返し、`filter()`で除外することでエラーを防止

## テスト
- [x] カレンダーページにアクセスしてエラーが発生しないことを確認
- [x] データ不整合があるスケジュールは表示されないが、エラーは発生しないことを確認