### PR TITLE
カレンダーUI改善: スケジュールと入浴予定の分離

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -86,12 +86,6 @@ class CalendarController extends Controller
             'total' => $schedules->count(),
         ];
 
-        \Illuminate\Support\Facades\Log::info('CalendarController::index', [
-            'date' => $date,
-            'events_count' => $events->count(),
-            'residents_count' => $residents->count(),
-            'first_event' => $events->first(),
-        ]);
 
         return Inertia::render('Calendar/Index', [
             'events' => $events,

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Request;
 use Inertia\Inertia;
 use App\Services\ScheduleService;
 use App\Models\Resident;
-use App\Models\ScheduleType;
 use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
 
@@ -217,23 +216,9 @@ class CalendarController extends Controller
                 ];
             });
 
-        // スケジュール種別一覧を取得
-        $scheduleTypes = ScheduleType::where('tenant_id', $currentTenantId)
-            ->orderBy('sort_order')
-            ->get()
-            ->map(function ($type) {
-                return [
-                    'id' => $type->id,
-                    'name' => $type->name,
-                    'color' => $type->color ?? '#3B82F6',
-                    'description' => $type->description,
-                ];
-            });
-
         return Inertia::render('Calendar/Day', [
             'events' => $events,
             'residents' => $residents,
-            'scheduleTypes' => $scheduleTypes,
             'currentDate' => $date,
         ]);
     }

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -86,6 +86,13 @@ class CalendarController extends Controller
             'total' => $schedules->count(),
         ];
 
+        \Illuminate\Support\Facades\Log::info('CalendarController::index', [
+            'date' => $date,
+            'events_count' => $events->count(),
+            'residents_count' => $residents->count(),
+            'first_event' => $events->first(),
+        ]);
+
         return Inertia::render('Calendar/Index', [
             'events' => $events,
             'residents' => $residents,

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -54,16 +54,15 @@ class CalendarController extends Controller
             
             return [
                 'id' => $schedule->id,
-                'title' => $schedule->resident->name . ' - ' . $schedule->scheduleType->name,
+                'title' => ($schedule->resident ? $schedule->resident->name . ' - ' : '') . $schedule->schedule_name,
                 'start' => $startDateTime->toIso8601String(),
                 'end' => $endDateTime->toIso8601String(),
-                'backgroundColor' => $schedule->scheduleType->color ?? '#3B82F6',
-                'borderColor' => $schedule->scheduleType->color ?? '#3B82F6',
+                'backgroundColor' => '#3B82F6',
+                'borderColor' => '#3B82F6',
                 'extendedProps' => [
                     'resident_id' => $schedule->resident_id,
-                    'resident_name' => $schedule->resident->name,
-                    'schedule_type_id' => $schedule->schedule_type_id,
-                    'schedule_type_name' => $schedule->scheduleType->name,
+                    'resident_name' => $schedule->resident ? $schedule->resident->name : null,
+                    'schedule_name' => $schedule->schedule_name,
                     'memo' => $schedule->memo,
                 ],
             ];
@@ -81,31 +80,14 @@ class CalendarController extends Controller
                 ];
             });
 
-        // スケジュール種別一覧を取得
-        $scheduleTypes = ScheduleType::where('tenant_id', $currentTenantId)
-            ->orderBy('sort_order')
-            ->get()
-            ->map(function ($type) {
-                return [
-                    'id' => $type->id,
-                    'name' => $type->name,
-                    'color' => $type->color ?? '#3B82F6',
-                    'description' => $type->description,
-                ];
-            });
-
         // 月間統計情報を計算
         $monthStats = [
             'total' => $schedules->count(),
-            'by_type' => $scheduleTypes->mapWithKeys(function ($type) use ($schedules) {
-                return [$type['id'] => $schedules->where('schedule_type_id', $type['id'])->count()];
-            }),
         ];
 
         return Inertia::render('Calendar/Index', [
             'events' => $events,
             'residents' => $residents,
-            'scheduleTypes' => $scheduleTypes,
             'monthStats' => $monthStats,
             'currentDate' => $date,
         ]);
@@ -144,16 +126,15 @@ class CalendarController extends Controller
             
             return [
                 'id' => $schedule->id,
-                'title' => $schedule->resident->name . ' - ' . $schedule->scheduleType->name,
+                'title' => ($schedule->resident ? $schedule->resident->name . ' - ' : '') . $schedule->schedule_name,
                 'start' => $startDateTime->toIso8601String(),
                 'end' => $endDateTime->toIso8601String(),
-                'backgroundColor' => $schedule->scheduleType->color ?? '#3B82F6',
-                'borderColor' => $schedule->scheduleType->color ?? '#3B82F6',
+                'backgroundColor' => '#3B82F6',
+                'borderColor' => '#3B82F6',
                 'extendedProps' => [
                     'resident_id' => $schedule->resident_id,
-                    'resident_name' => $schedule->resident->name,
-                    'schedule_type_id' => $schedule->schedule_type_id,
-                    'schedule_type_name' => $schedule->scheduleType->name,
+                    'resident_name' => $schedule->resident ? $schedule->resident->name : null,
+                    'schedule_name' => $schedule->schedule_name,
                     'memo' => $schedule->memo,
                 ],
             ];
@@ -171,23 +152,9 @@ class CalendarController extends Controller
                 ];
             });
 
-        // スケジュール種別一覧を取得
-        $scheduleTypes = ScheduleType::where('tenant_id', $currentTenantId)
-            ->orderBy('sort_order')
-            ->get()
-            ->map(function ($type) {
-                return [
-                    'id' => $type->id,
-                    'name' => $type->name,
-                    'color' => $type->color ?? '#3B82F6',
-                    'description' => $type->description,
-                ];
-            });
-
         return Inertia::render('Calendar/Week', [
             'events' => $events,
             'residents' => $residents,
-            'scheduleTypes' => $scheduleTypes,
             'currentDate' => $date,
             'startOfWeek' => $startOfWeek,
             'endOfWeek' => $endOfWeek,
@@ -224,16 +191,15 @@ class CalendarController extends Controller
             
             return [
                 'id' => $schedule->id,
-                'title' => $schedule->resident->name . ' - ' . $schedule->scheduleType->name,
+                'title' => ($schedule->resident ? $schedule->resident->name . ' - ' : '') . $schedule->schedule_name,
                 'start' => $startDateTime->toIso8601String(),
                 'end' => $endDateTime->toIso8601String(),
-                'backgroundColor' => $schedule->scheduleType->color ?? '#3B82F6',
-                'borderColor' => $schedule->scheduleType->color ?? '#3B82F6',
+                'backgroundColor' => '#3B82F6',
+                'borderColor' => '#3B82F6',
                 'extendedProps' => [
                     'resident_id' => $schedule->resident_id,
-                    'resident_name' => $schedule->resident->name,
-                    'schedule_type_id' => $schedule->schedule_type_id,
-                    'schedule_type_name' => $schedule->scheduleType->name,
+                    'resident_name' => $schedule->resident ? $schedule->resident->name : null,
+                    'schedule_name' => $schedule->schedule_name,
                     'memo' => $schedule->memo,
                 ],
             ];

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -43,7 +43,9 @@ class CalendarController extends Controller
             'date_to' => $endOfMonth,
         ];
         // 月間データなので全件取得（perPageをnullにすることで全件取得）
-        $schedules = $this->scheduleService->getSchedules($filters, PHP_INT_MAX);
+        $schedulesPaginator = $this->scheduleService->getSchedules($filters, PHP_INT_MAX);
+        // Paginatorからコレクションを取得
+        $schedules = $schedulesPaginator->getCollection();
 
         // FullCalendar用のイベント形式に変換
         $events = $schedules->map(function ($schedule) {
@@ -116,7 +118,9 @@ class CalendarController extends Controller
             'date_from' => $startOfWeek,
             'date_to' => $endOfWeek,
         ];
-        $schedules = $this->scheduleService->getSchedules($filters, PHP_INT_MAX);
+        $schedulesPaginator = $this->scheduleService->getSchedules($filters, PHP_INT_MAX);
+        // Paginatorからコレクションを取得
+        $schedules = $schedulesPaginator->getCollection();
 
         // FullCalendar用のイベント形式に変換
         $events = $schedules->map(function ($schedule) {
@@ -181,7 +185,9 @@ class CalendarController extends Controller
             'date_from' => $carbonDate->format('Y-m-d'),
             'date_to' => $carbonDate->format('Y-m-d'),
         ];
-        $schedules = $this->scheduleService->getSchedules($filters, PHP_INT_MAX);
+        $schedulesPaginator = $this->scheduleService->getSchedules($filters, PHP_INT_MAX);
+        // Paginatorからコレクションを取得
+        $schedules = $schedulesPaginator->getCollection();
 
         // FullCalendar用のイベント形式に変換
         $events = $schedules->map(function ($schedule) {

--- a/app/Http/Requests/Schedule/ScheduleStoreRequest.php
+++ b/app/Http/Requests/Schedule/ScheduleStoreRequest.php
@@ -30,7 +30,6 @@ class ScheduleStoreRequest extends FormRequest
         return [
             'date' => 'required|date|date_format:Y-m-d',
             'schedule_name' => 'required|string|max:255',
-            'schedule_type_id' => 'required|exists:schedule_types,id',
             'start_time' => 'required|date_format:H:i',
             'end_time' => 'required|date_format:H:i|after:start_time',
             'memo' => 'nullable|string|max:1000',
@@ -51,8 +50,6 @@ class ScheduleStoreRequest extends FormRequest
             'schedule_name.required' => 'スケジュール名は必須です。',
             'schedule_name.string' => 'スケジュール名は文字列で入力してください。',
             'schedule_name.max' => 'スケジュール名は255文字以内で入力してください。',
-            'schedule_type_id.required' => 'スケジュール種別の指定は必須です。',
-            'schedule_type_id.exists' => '指定されたスケジュール種別が存在しません。',
             'start_time.required' => '開始時刻は必須です。',
             'start_time.date_format' => '開始時刻はHH:MM形式で入力してください。',
             'end_time.required' => '終了時刻は必須です。',

--- a/app/Http/Requests/Schedule/ScheduleStoreRequest.php
+++ b/app/Http/Requests/Schedule/ScheduleStoreRequest.php
@@ -29,7 +29,7 @@ class ScheduleStoreRequest extends FormRequest
     {
         return [
             'date' => 'required|date|date_format:Y-m-d',
-            'resident_id' => 'required|exists:residents,id',
+            'schedule_name' => 'required|string|max:255',
             'schedule_type_id' => 'required|exists:schedule_types,id',
             'start_time' => 'required|date_format:H:i',
             'end_time' => 'required|date_format:H:i|after:start_time',
@@ -48,8 +48,9 @@ class ScheduleStoreRequest extends FormRequest
             'date.required' => '日付は必須です。',
             'date.date' => '日付の形式が正しくありません。',
             'date.date_format' => '日付はYYYY-MM-DD形式で入力してください。',
-            'resident_id.required' => '利用者の指定は必須です。',
-            'resident_id.exists' => '指定された利用者が存在しません。',
+            'schedule_name.required' => 'スケジュール名は必須です。',
+            'schedule_name.string' => 'スケジュール名は文字列で入力してください。',
+            'schedule_name.max' => 'スケジュール名は255文字以内で入力してください。',
             'schedule_type_id.required' => 'スケジュール種別の指定は必須です。',
             'schedule_type_id.exists' => '指定されたスケジュール種別が存在しません。',
             'start_time.required' => '開始時刻は必須です。',

--- a/app/Http/Requests/Schedule/ScheduleStoreRequest.php
+++ b/app/Http/Requests/Schedule/ScheduleStoreRequest.php
@@ -29,6 +29,7 @@ class ScheduleStoreRequest extends FormRequest
     {
         return [
             'date' => 'required|date|date_format:Y-m-d',
+            'resident_id' => 'nullable|integer|exists:residents,id',
             'schedule_name' => 'required|string|max:255',
             'start_time' => 'required|date_format:H:i',
             'end_time' => 'required|date_format:H:i|after:start_time',

--- a/app/Http/Requests/Schedule/ScheduleUpdateRequest.php
+++ b/app/Http/Requests/Schedule/ScheduleUpdateRequest.php
@@ -39,13 +39,6 @@ class ScheduleUpdateRequest extends FormRequest
                     $query->where('tenant_id', $tenantId);
                 }),
             ],
-            'schedule_type_id' => [
-                'required',
-                'exists:schedule_types,id',
-                Rule::exists('schedule_types', 'id')->where(function ($query) use ($tenantId) {
-                    $query->where('tenant_id', $tenantId);
-                }),
-            ],
             'start_time' => 'required|date_format:H:i',
             'end_time' => 'required|date_format:H:i|after:start_time',
             'memo' => 'nullable|string|max:1000',
@@ -65,8 +58,6 @@ class ScheduleUpdateRequest extends FormRequest
             'date.date_format' => '日付はYYYY-MM-DD形式で入力してください。',
             'resident_id.required' => '利用者の指定は必須です。',
             'resident_id.exists' => '指定された利用者は存在しないか、アクセスできません。',
-            'schedule_type_id.required' => 'スケジュール種別の指定は必須です。',
-            'schedule_type_id.exists' => '指定されたスケジュール種別は存在しないか、アクセスできません。',
             'start_time.required' => '開始時刻は必須です。',
             'start_time.date_format' => '開始時刻はHH:MM形式で入力してください。',
             'end_time.required' => '終了時刻は必須です。',

--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -15,6 +15,7 @@ class Schedule extends Model
         'tenant_id',
         'calendar_date_id',
         'resident_id',
+        'schedule_name',
         'schedule_type_id',
         'start_time',
         'end_time',

--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -44,13 +44,6 @@ class Schedule extends Model
         return $this->belongsTo(Resident::class);
     }
 
-    /**
-     * 種別とのリレーション
-     */
-    public function scheduleType()
-    {
-        return $this->belongsTo(ScheduleType::class);
-    }
 
     /**
      * 作成者とのリレーション

--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -44,6 +44,13 @@ class Schedule extends Model
         return $this->belongsTo(Resident::class);
     }
 
+    /**
+     * スケジュールタイプとのリレーション
+     */
+    public function scheduleType()
+    {
+        return $this->belongsTo(ScheduleType::class);
+    }
 
     /**
      * 作成者とのリレーション

--- a/app/Policies/SchedulePolicy.php
+++ b/app/Policies/SchedulePolicy.php
@@ -95,7 +95,21 @@ class SchedulePolicy
      */
     public function delete(User $user, Schedule $schedule): bool
     {
-        // updateと同じロジック
-        return $this->update($user, $schedule);
+        // テナント境界チェック（必須）
+        if (!$this->checkTenantBoundary($user, $schedule)) {
+            return false;
+        }
+
+        // 権限チェック
+        if (!$user->hasPermissionTo('schedules.delete')) {
+            return false;
+        }
+
+        // 一般ユーザーは自分が作成したスケジュールのみ削除可能
+        if (!$user->hasRole('admin') && $schedule->created_by !== $user->id) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/app/Services/ScheduleService.php
+++ b/app/Services/ScheduleService.php
@@ -36,7 +36,6 @@ class ScheduleService
             ->with([
                 'calendarDate',
                 'resident',
-                'scheduleType',
                 'creator' => function ($q) use ($currentTenantId) {
                     $q->select('id', 'name', 'tenant_id')
                       ->where('tenant_id', $currentTenantId);
@@ -61,10 +60,6 @@ class ScheduleService
             $query->where('resident_id', $filters['resident_id']);
         }
 
-        // 種別IDでフィルタリング
-        if (isset($filters['schedule_type_id'])) {
-            $query->where('schedule_type_id', $filters['schedule_type_id']);
-        }
 
         return $query->orderBy('start_time')->paginate($perPage);
     }
@@ -87,17 +82,12 @@ class ScheduleService
         $calendarDate = $this->ensureCalendarDate($validated['date'], $currentTenantId);
 
         return DB::transaction(function () use ($validated, $currentTenantId, $currentUser, $calendarDate) {
-            // 種別のテナント境界チェック
-            $scheduleType = ScheduleType::findOrFail($validated['schedule_type_id']);
-            $this->validateTenantBoundary($scheduleType);
-
             // スケジュール作成
             $schedule = Schedule::create([
                 'tenant_id' => $currentTenantId,
                 'calendar_date_id' => $calendarDate->id,
                 'resident_id' => $validated['resident_id'] ?? null,
                 'schedule_name' => $validated['schedule_name'],
-                'schedule_type_id' => $validated['schedule_type_id'],
                 'start_time' => $validated['start_time'],
                 'end_time' => $validated['end_time'],
                 'memo' => $validated['memo'] ?? null,
@@ -186,10 +176,6 @@ class ScheduleService
             $resident = Resident::findOrFail($validated['resident_id']);
             $this->validateTenantBoundary($resident);
 
-            // 種別のテナント境界チェック
-            $scheduleType = ScheduleType::findOrFail($validated['schedule_type_id']);
-            $this->validateTenantBoundary($scheduleType);
-
             // 詳細な重複チェック（M2：時間帯の重複検証）
             $this->validateNoConflict(
                 $validated['resident_id'],
@@ -203,7 +189,7 @@ class ScheduleService
             $schedule->update([
                 'calendar_date_id' => $calendarDate->id,
                 'resident_id' => $validated['resident_id'],
-                'schedule_type_id' => $validated['schedule_type_id'],
+                'schedule_name' => $validated['schedule_name'] ?? $schedule->schedule_name,
                 'start_time' => $validated['start_time'],
                 'end_time' => $validated['end_time'],
                 'memo' => $validated['memo'] ?? null,

--- a/database/migrations/2025_11_10_085719_add_schedule_name_to_schedules_table.php
+++ b/database/migrations/2025_11_10_085719_add_schedule_name_to_schedules_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('schedules', function (Blueprint $table) {
+            $table->string('schedule_name')->nullable()->after('resident_id');
+            $table->unsignedBigInteger('resident_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('schedules', function (Blueprint $table) {
+            $table->dropColumn('schedule_name');
+            $table->unsignedBigInteger('resident_id')->nullable(false)->change();
+        });
+    }
+};

--- a/database/migrations/2025_11_10_090018_remove_schedule_type_id_from_schedules_table.php
+++ b/database/migrations/2025_11_10_090018_remove_schedule_type_id_from_schedules_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('schedules', function (Blueprint $table) {
+            // 外部キー制約を削除
+            $table->dropForeign(['schedule_type_id']);
+            // インデックスを削除
+            $table->dropIndex(['schedule_type_id']);
+            // カラムを削除
+            $table->dropColumn('schedule_type_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('schedules', function (Blueprint $table) {
+            // カラムを追加
+            $table->unsignedBigInteger('schedule_type_id')->after('schedule_name');
+            // インデックスを追加
+            $table->index('schedule_type_id');
+            // 外部キー制約を追加
+            if (Schema::getConnection()->getDriverName() === 'mysql') {
+                $table->foreign('schedule_type_id')
+                    ->references('id')
+                    ->on('schedule_types')
+                    ->onDelete('restrict');
+            }
+        });
+    }
+};

--- a/resources/js/Components/ScheduleForm.vue
+++ b/resources/js/Components/ScheduleForm.vue
@@ -1,8 +1,8 @@
 <script setup>
-import { ref, watch } from 'vue'
-import { useForm } from '@inertiajs/vue3'
-import Modal from './Modal.vue'
-import dayjs from 'dayjs'
+import { ref, watch } from "vue";
+import { useForm } from "@inertiajs/vue3";
+import Modal from "./Modal.vue";
+import dayjs from "dayjs";
 
 const props = defineProps({
     show: {
@@ -25,73 +25,76 @@ const props = defineProps({
         type: Array,
         default: () => [],
     },
-})
+});
 
-const emit = defineEmits(['close', 'success'])
+const emit = defineEmits(["close", "success"]);
 
 const form = useForm({
-    date: props.initialDate || dayjs().format('YYYY-MM-DD'),
+    date: props.initialDate || dayjs().format("YYYY-MM-DD"),
     resident_id: props.initialResidentId || null,
+    schedule_name: "",
     schedule_type_id: null,
-    start_time: '09:00',
-    end_time: '10:00',
-    memo: '',
-})
+    start_time: "09:00",
+    end_time: "10:00",
+    memo: "",
+});
 
 // propsの変更を監視してフォームを更新
 watch(
     () => props.initialDate,
     (newDate) => {
         if (newDate) {
-            form.date = newDate
+            form.date = newDate;
         }
     }
-)
+);
 
 watch(
     () => props.initialResidentId,
     (newResidentId) => {
         if (newResidentId) {
-            form.resident_id = newResidentId
+            form.resident_id = newResidentId;
         }
     }
-)
+);
 
 // モーダルが閉じられたときにフォームをリセット
 watch(
     () => props.show,
     (isOpen) => {
         if (!isOpen) {
-            form.reset()
-            form.clearErrors()
+            form.reset();
+            form.clearErrors();
         }
     }
-)
+);
 
 const submit = () => {
-    form.post(route('calendar.schedule.store'), {
+    form.post(route("calendar.schedule.store"), {
         preserveScroll: true,
         onSuccess: () => {
-            emit('success')
-            emit('close')
-            form.reset()
+            emit("success");
+            emit("close");
+            form.reset();
         },
         onError: () => {
             // エラーはform.errorsに自動的に設定される
         },
-    })
-}
+    });
+};
 
 const close = () => {
-    emit('close')
-}
+    emit("close");
+};
 </script>
 
 <template>
     <Modal :show="show" max-width="2xl" @close="close">
         <div class="p-6">
             <div class="flex items-center justify-between mb-4">
-                <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">
+                <h2
+                    class="text-xl font-semibold text-gray-900 dark:text-gray-100"
+                >
                     スケジュール作成
                 </h2>
                 <button
@@ -118,39 +121,35 @@ const close = () => {
                         class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
                         :class="{ 'border-red-500': form.errors.date }"
                     />
-                    <div v-if="form.errors.date" class="mt-1 text-sm text-red-600 dark:text-red-400">
+                    <div
+                        v-if="form.errors.date"
+                        class="mt-1 text-sm text-red-600 dark:text-red-400"
+                    >
                         {{ form.errors.date }}
                     </div>
                 </div>
 
-                <!-- 利用者 -->
+                <!-- スケジュール名 -->
                 <div class="mb-4">
                     <label
-                        for="resident_id"
+                        for="schedule_name"
                         class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
                     >
-                        利用者 <span class="text-red-500">*</span>
+                        スケジュール名 <span class="text-red-500">*</span>
                     </label>
-                    <select
-                        id="resident_id"
-                        v-model="form.resident_id"
+                    <input
+                        id="schedule_name"
+                        v-model="form.schedule_name"
+                        type="text"
+                        placeholder="スケジュール名を入力してください"
                         class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                        :class="{ 'border-red-500': form.errors.resident_id }"
-                    >
-                        <option value="">選択してください</option>
-                        <option
-                            v-for="resident in residents"
-                            :key="resident.id"
-                            :value="resident.id"
-                        >
-                            {{ resident.name }}
-                        </option>
-                    </select>
+                        :class="{ 'border-red-500': form.errors.schedule_name }"
+                    />
                     <div
-                        v-if="form.errors.resident_id"
+                        v-if="form.errors.schedule_name"
                         class="mt-1 text-sm text-red-600 dark:text-red-400"
                     >
-                        {{ form.errors.resident_id }}
+                        {{ form.errors.schedule_name }}
                     </div>
                 </div>
 
@@ -166,7 +165,9 @@ const close = () => {
                         id="schedule_type_id"
                         v-model="form.schedule_type_id"
                         class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                        :class="{ 'border-red-500': form.errors.schedule_type_id }"
+                        :class="{
+                            'border-red-500': form.errors.schedule_type_id,
+                        }"
                     >
                         <option value="">選択してください</option>
                         <option
@@ -199,7 +200,9 @@ const close = () => {
                             v-model="form.start_time"
                             type="time"
                             class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                            :class="{ 'border-red-500': form.errors.start_time }"
+                            :class="{
+                                'border-red-500': form.errors.start_time,
+                            }"
                         />
                         <div
                             v-if="form.errors.start_time"
@@ -246,7 +249,10 @@ const close = () => {
                         class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
                         :class="{ 'border-red-500': form.errors.memo }"
                     ></textarea>
-                    <div v-if="form.errors.memo" class="mt-1 text-sm text-red-600 dark:text-red-400">
+                    <div
+                        v-if="form.errors.memo"
+                        class="mt-1 text-sm text-red-600 dark:text-red-400"
+                    >
                         {{ form.errors.memo }}
                     </div>
                 </div>
@@ -265,11 +271,10 @@ const close = () => {
                         :disabled="form.processing"
                         class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                        {{ form.processing ? '作成中...' : '作成' }}
+                        {{ form.processing ? "作成中..." : "作成" }}
                     </button>
                 </div>
             </form>
         </div>
     </Modal>
 </template>
-

--- a/resources/js/Components/ScheduleForm.vue
+++ b/resources/js/Components/ScheduleForm.vue
@@ -33,7 +33,6 @@ const form = useForm({
     date: props.initialDate || dayjs().format("YYYY-MM-DD"),
     resident_id: props.initialResidentId || null,
     schedule_name: "",
-    schedule_type_id: null,
     start_time: "09:00",
     end_time: "10:00",
     memo: "",
@@ -150,39 +149,6 @@ const close = () => {
                         class="mt-1 text-sm text-red-600 dark:text-red-400"
                     >
                         {{ form.errors.schedule_name }}
-                    </div>
-                </div>
-
-                <!-- スケジュール種別 -->
-                <div class="mb-4">
-                    <label
-                        for="schedule_type_id"
-                        class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-                    >
-                        スケジュール種別 <span class="text-red-500">*</span>
-                    </label>
-                    <select
-                        id="schedule_type_id"
-                        v-model="form.schedule_type_id"
-                        class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                        :class="{
-                            'border-red-500': form.errors.schedule_type_id,
-                        }"
-                    >
-                        <option value="">選択してください</option>
-                        <option
-                            v-for="type in scheduleTypes"
-                            :key="type.id"
-                            :value="type.id"
-                        >
-                            {{ type.name }}
-                        </option>
-                    </select>
-                    <div
-                        v-if="form.errors.schedule_type_id"
-                        class="mt-1 text-sm text-red-600 dark:text-red-400"
-                    >
-                        {{ form.errors.schedule_type_id }}
                     </div>
                 </div>
 

--- a/resources/js/Components/ScheduleForm.vue
+++ b/resources/js/Components/ScheduleForm.vue
@@ -26,6 +26,10 @@ const props = defineProps({
         type: Array,
         default: () => [],
     },
+    title: {
+        type: String,
+        default: "スケジュール作成",
+    },
 });
 
 const emit = defineEmits(["close", "success"]);
@@ -152,7 +156,7 @@ const close = () => {
                 <h2
                     class="text-xl font-semibold text-gray-900 dark:text-gray-100"
                 >
-                    スケジュール作成
+                    {{ title }}
                 </h2>
                 <button
                     @click="close"

--- a/resources/js/Components/ScheduleModal.vue
+++ b/resources/js/Components/ScheduleModal.vue
@@ -101,8 +101,8 @@ const deleteSchedule = async () => {
         })
 
         // 削除されたスケジュールIDを親コンポーネントに渡す
+        // モーダルの閉じる処理は親コンポーネントのhandleScheduleDeleted内で行う
         emit('deleted', props.schedule.id)
-        emit('close')
     } catch (error) {
         console.error('ScheduleModal delete error:', error)
         

--- a/resources/js/Components/ScheduleModal.vue
+++ b/resources/js/Components/ScheduleModal.vue
@@ -315,10 +315,10 @@ const cancelEdit = () => {
                         </div>
                         <div>
                             <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">
-                                利用者
+                                スケジュール名
                             </dt>
                             <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">
-                                {{ schedule.extendedProps?.resident_name || '-' }}
+                                {{ schedule.extendedProps?.schedule_type_name || '-' }}
                             </dd>
                         </div>
                         <div>

--- a/resources/js/Components/ScheduleModal.vue
+++ b/resources/js/Components/ScheduleModal.vue
@@ -100,7 +100,8 @@ const deleteSchedule = async () => {
             },
         })
 
-        emit('deleted')
+        // 削除されたスケジュールIDを親コンポーネントに渡す
+        emit('deleted', props.schedule.id)
         emit('close')
     } catch (error) {
         console.error('ScheduleModal delete error:', error)

--- a/resources/js/Pages/Calendar/Day.vue
+++ b/resources/js/Pages/Calendar/Day.vue
@@ -1,0 +1,172 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { Head, usePage, router } from '@inertiajs/vue3'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+import FullCalendar from '@fullcalendar/vue3'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import timeGridPlugin from '@fullcalendar/timegrid'
+import interactionPlugin from '@fullcalendar/interaction'
+import dayjs from 'dayjs'
+import 'dayjs/locale/ja'
+import jaLocale from '@fullcalendar/core/locales/ja.js'
+import ScheduleForm from '@/Components/ScheduleForm.vue'
+import ScheduleModal from '@/Components/ScheduleModal.vue'
+
+dayjs.locale('ja')
+
+const { props } = usePage()
+
+const events = ref(props.events || [])
+const residents = ref(props.residents || [])
+const scheduleTypes = ref(props.scheduleTypes || [])
+const currentDate = ref(props.currentDate || dayjs().format('YYYY-MM-DD'))
+
+// スケジュール作成フォームの表示状態
+const showScheduleForm = ref(false)
+const formInitialDate = ref(null)
+const formInitialResidentId = ref(null)
+
+// スケジュール詳細モーダルの表示状態
+const showScheduleModal = ref(false)
+const selectedSchedule = ref(null)
+
+// カレンダーの日変更時の処理
+const handleDayChange = (info) => {
+    // 日が変更された場合、新しい日のデータを取得
+    const newDate = dayjs(info.start).format('YYYY-MM-DD')
+    const currentDay = dayjs(currentDate.value).format('YYYY-MM-DD')
+    
+    if (newDate !== currentDay) {
+        // Inertiaでページを再読み込み
+        router.get(route('calendar.day', { date: newDate }), {}, {
+            preserveState: true,
+            preserveScroll: true,
+        })
+    }
+}
+
+// 日付クリック時の処理
+const handleDateClick = (info) => {
+    formInitialDate.value = dayjs(info.date).format('YYYY-MM-DD')
+    formInitialResidentId.value = null
+    showScheduleForm.value = true
+}
+
+// イベントクリック時の処理
+const handleEventClick = (info) => {
+    selectedSchedule.value = info.event
+    showScheduleModal.value = true
+}
+
+// FullCalendarの設定
+const calendarOptions = computed(() => ({
+    plugins: [dayGridPlugin, timeGridPlugin, interactionPlugin],
+    initialView: 'timeGridDay',
+    locale: jaLocale,
+    headerToolbar: {
+        left: 'prev,next today',
+        center: 'title',
+        right: 'dayGridMonth,timeGridWeek,timeGridDay',
+    },
+    buttonText: {
+        today: '今日',
+        month: '月',
+        week: '週',
+        day: '日',
+    },
+    events: events.value,
+    eventDisplay: 'block',
+    height: 'auto',
+    editable: false, // 編集はモーダルから行う
+    selectable: false, // 範囲選択は無効 - 日付クリックで作成フォームを表示
+    dateClick: handleDateClick, // 日付クリック時の処理
+    eventClick: handleEventClick, // イベントクリック時の処理
+    slotMinTime: '06:00:00',
+    slotMaxTime: '22:00:00',
+    slotDuration: '00:30:00',
+    initialDate: currentDate.value,
+}))
+
+// スケジュール作成成功時の処理
+const handleScheduleCreated = () => {
+    // カレンダーを再読み込み
+    router.reload({ only: ['events'] })
+}
+
+// フォームを閉じる
+const closeScheduleForm = () => {
+    showScheduleForm.value = false
+    formInitialDate.value = null
+    formInitialResidentId.value = null
+}
+
+// スケジュール更新成功時の処理
+const handleScheduleUpdated = () => {
+    // カレンダーを再読み込み
+    router.reload({ only: ['events'] })
+}
+
+// スケジュール削除成功時の処理
+const handleScheduleDeleted = () => {
+    // カレンダーを再読み込み
+    router.reload({ only: ['events'] })
+}
+
+// モーダルを閉じる
+const closeScheduleModal = () => {
+    showScheduleModal.value = false
+    selectedSchedule.value = null
+}
+</script>
+
+<template>
+    <AuthenticatedLayout>
+        <Head title="日間カレンダー" />
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900 dark:text-gray-100">
+                        <h1 class="text-2xl font-bold mb-6">
+                            日間カレンダー - {{ dayjs(currentDate).format('YYYY年MM月DD日') }}
+                        </h1>
+
+                        <!-- カレンダー表示 -->
+                        <div class="calendar-container">
+                            <FullCalendar :options="calendarOptions" @datesSet="handleDayChange" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- スケジュール作成フォーム -->
+        <ScheduleForm
+            :show="showScheduleForm"
+            :initial-date="formInitialDate"
+            :initial-resident-id="formInitialResidentId"
+            :residents="residents"
+            :schedule-types="scheduleTypes"
+            @close="closeScheduleForm"
+            @success="handleScheduleCreated"
+        />
+
+        <!-- スケジュール詳細モーダル -->
+        <ScheduleModal
+            :show="showScheduleModal"
+            :schedule="selectedSchedule"
+            :residents="residents"
+            :schedule-types="scheduleTypes"
+            @close="closeScheduleModal"
+            @updated="handleScheduleUpdated"
+            @deleted="handleScheduleDeleted"
+        />
+    </AuthenticatedLayout>
+</template>
+
+<style>
+.calendar-container {
+    margin-top: 1rem;
+}
+</style>
+

--- a/resources/js/Pages/Calendar/Day.vue
+++ b/resources/js/Pages/Calendar/Day.vue
@@ -66,6 +66,16 @@ const handleDayChange = (info) => {
 
 // 日付クリック時の処理
 const handleDateClick = (info) => {
+    // イベントがクリックされた場合は何もしない（eventClickで処理される）
+    const clickedElement = info.jsEvent?.target;
+    if (clickedElement) {
+        // イベント要素がクリックされた場合は無視
+        const eventElement = clickedElement.closest('.fc-event');
+        if (eventElement) {
+            return; // イベントクリックで処理されるため、dateClickは無視
+        }
+    }
+    
     formInitialDate.value = dayjs(info.date).format('YYYY-MM-DD')
     formInitialResidentId.value = null
     showScheduleForm.value = true
@@ -73,6 +83,9 @@ const handleDateClick = (info) => {
 
 // イベントクリック時の処理
 const handleEventClick = (info) => {
+    // スケジュール作成フォームを閉じる（誤って開かないように）
+    showScheduleForm.value = false
+    
     selectedSchedule.value = info.event
     showScheduleModal.value = true
 }
@@ -140,6 +153,9 @@ const handleScheduleUpdated = () => {
 const handleScheduleDeleted = (deletedScheduleId) => {
     console.log('handleScheduleDeleted called (Day)', deletedScheduleId);
     
+    // まずモーダルを閉じる（確実に閉じるため）
+    closeScheduleModal();
+    
     if (deletedScheduleId) {
         // 削除されたスケジュールをeventsから直接削除
         events.value = events.value.filter(event => event.id !== deletedScheduleId);
@@ -151,9 +167,6 @@ const handleScheduleDeleted = (deletedScheduleId) => {
             calendarApi.refetchEvents();
         }
     }
-    
-    // モーダルを閉じる
-    closeScheduleModal();
 }
 
 // モーダルを閉じる

--- a/resources/js/Pages/Calendar/Day.vue
+++ b/resources/js/Pages/Calendar/Day.vue
@@ -137,9 +137,23 @@ const handleScheduleUpdated = () => {
 }
 
 // スケジュール削除成功時の処理
-const handleScheduleDeleted = () => {
-    // カレンダーを再読み込み
-    router.reload({ only: ['events'] })
+const handleScheduleDeleted = (deletedScheduleId) => {
+    console.log('handleScheduleDeleted called (Day)', deletedScheduleId);
+    
+    if (deletedScheduleId) {
+        // 削除されたスケジュールをeventsから直接削除
+        events.value = events.value.filter(event => event.id !== deletedScheduleId);
+        console.log('Removed deleted event from events.value:', events.value.length);
+        
+        // FullCalendarのイベントを更新
+        if (calendarRef.value) {
+            const calendarApi = calendarRef.value.getApi();
+            calendarApi.refetchEvents();
+        }
+    }
+    
+    // モーダルを閉じる
+    closeScheduleModal();
 }
 
 // モーダルを閉じる

--- a/resources/js/Pages/Calendar/Day.vue
+++ b/resources/js/Pages/Calendar/Day.vue
@@ -98,7 +98,21 @@ const calendarOptions = computed(() => ({
     headerToolbar: {
         left: 'prev,next today',
         center: 'title',
-        right: 'dayGridMonth,timeGridWeek,timeGridDay',
+        right: 'customMonth,customWeek,timeGridDay',
+    },
+    customButtons: {
+        customMonth: {
+            text: '月',
+            click: () => {
+                router.get(route('calendar.index'), { date: currentDate.value });
+            }
+        },
+        customWeek: {
+            text: '週',
+            click: () => {
+                router.get(route('calendar.week'), { date: currentDate.value });
+            }
+        }
     },
     buttonText: {
         today: '今日',
@@ -117,6 +131,7 @@ const calendarOptions = computed(() => ({
     slotMaxTime: '22:00:00',
     slotDuration: '00:30:00',
     initialDate: currentDate.value,
+    allDaySlot: false, // 終日スロットを非表示（必要に応じて有効化）
 }))
 
 // スケジュール作成成功時の処理
@@ -180,14 +195,22 @@ const closeScheduleModal = () => {
     <AuthenticatedLayout>
         <Head title="日間カレンダー" />
 
-        <div class="py-12">
-            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
-                    <div class="p-6 text-gray-900 dark:text-gray-100">
-                        <h1 class="text-2xl font-bold mb-6">
+        <div class="py-8 bg-gray-50 dark:bg-gray-900 min-h-screen">
+            <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-8">
+                
+                <!-- ヘッダーエリア -->
+                <div class="flex flex-col md:flex-row justify-between items-center mb-8 gap-4">
+                    <div>
+                        <h1 class="text-3xl font-bold text-gray-800 dark:text-gray-100 tracking-tight">
                             日間カレンダー - {{ dayjs(currentDate).format('YYYY年MM月DD日') }}
                         </h1>
+                        <p class="text-gray-500 dark:text-gray-400 mt-1">1日の詳細スケジュールを確認できます</p>
+                    </div>
+                </div>
 
+                <!-- カレンダーメインエリア -->
+                <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
+                    <div class="p-6">
                         <!-- カレンダー表示 -->
                         <div class="calendar-container">
                             <FullCalendar ref="calendarRef" :options="calendarOptions" @datesSet="handleDayChange" />
@@ -221,9 +244,151 @@ const closeScheduleModal = () => {
     </AuthenticatedLayout>
 </template>
 
-<style>
+<style scoped>
+/* カレンダーコンテナ */
 .calendar-container {
-    margin-top: 1rem;
+    font-family: 'Inter', sans-serif;
+}
+
+/* FullCalendarの全体スタイル調整 */
+:deep(.fc) {
+    --fc-border-color: #f3f4f6;
+    --fc-today-bg-color: rgba(59, 130, 246, 0.05);
+    --fc-neutral-bg-color: #f9fafb;
+    --fc-page-bg-color: #ffffff;
+}
+
+.dark :deep(.fc) {
+    --fc-border-color: #374151;
+    --fc-neutral-bg-color: #1f2937;
+    --fc-page-bg-color: #1f2937;
+}
+
+/* ヘッダーツールバー */
+:deep(.fc-header-toolbar) {
+    margin-bottom: 1.5rem !important;
+}
+
+:deep(.fc-toolbar-title) {
+    font-size: 1.5rem !important;
+    font-weight: 700;
+    color: #1f2937;
+}
+
+.dark :deep(.fc-toolbar-title) {
+    color: #f3f4f6;
+}
+
+/* ボタンのカスタマイズ */
+:deep(.fc-button) {
+    background-color: white;
+    border: 1px solid #e5e7eb;
+    color: #374151;
+    font-weight: 500;
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    transition: all 0.2s;
+}
+
+:deep(.fc-button:hover) {
+    background-color: #f9fafb;
+    border-color: #d1d5db;
+    color: #111827;
+}
+
+:deep(.fc-button-primary:not(:disabled).fc-button-active),
+:deep(.fc-button-primary:not(:disabled):active) {
+    background-color: #3b82f6;
+    border-color: #3b82f6;
+    color: white;
+}
+
+.dark :deep(.fc-button) {
+    background-color: #374151;
+    border-color: #4b5563;
+    color: #e5e7eb;
+}
+
+.dark :deep(.fc-button:hover) {
+    background-color: #4b5563;
+}
+
+/* 曜日ヘッダー */
+:deep(.fc-col-header-cell) {
+    padding: 0.75rem 0;
+    background-color: #f9fafb;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+:deep(.fc-col-header-cell-cushion) {
+    color: #6b7280;
+    font-weight: 600;
+    text-decoration: none;
+    font-size: 0.875rem;
+}
+
+.dark :deep(.fc-col-header-cell) {
+    background-color: #1f2937;
+    border-bottom-color: #374151;
+}
+
+.dark :deep(.fc-col-header-cell-cushion) {
+    color: #9ca3af;
+}
+
+/* タイムグリッドのスロット */
+:deep(.fc-timegrid-slot) {
+    height: 3rem; /* スロットの高さを少し広げる */
+}
+
+:deep(.fc-timegrid-slot-label) {
+    font-size: 0.75rem;
+    color: #6b7280;
+    font-weight: 500;
+}
+
+/* イベントスタイル（TimeGrid用） */
+:deep(.fc-timegrid-event) {
+    border-radius: 6px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    border: none;
+    padding: 2px;
+    transition: transform 0.1s;
+}
+
+:deep(.fc-timegrid-event:hover) {
+    transform: scale(1.02);
+    z-index: 5;
+}
+
+:deep(.fc-event-main) {
+    padding: 2px 4px;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+/* スクロールバーのカスタマイズ */
+:deep(::-webkit-scrollbar) {
+    width: 6px;
+    height: 6px;
+}
+
+:deep(::-webkit-scrollbar-track) {
+    background: transparent;
+}
+
+:deep(::-webkit-scrollbar-thumb) {
+    background: #d1d5db;
+    border-radius: 3px;
+}
+
+:deep(::-webkit-scrollbar-thumb:hover) {
+    background: #9ca3af;
+}
+
+.dark :deep(::-webkit-scrollbar-thumb) {
+    background: #4b5563;
 }
 </style>
 

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -122,6 +122,34 @@ const dayCellContent = (info) => {
     }
 }
 
+// 日付セルがマウントされた後にクリックイベントをバインド
+const dayCellDidMount = (info) => {
+    // スケジュールアイテムのクリックイベントをバインド
+    const scheduleItems = info.el.querySelectorAll('.calendar-schedule-item')
+    scheduleItems.forEach(item => {
+        const eventId = item.getAttribute('data-event-id')
+        if (eventId) {
+            item.addEventListener('click', (e) => {
+                e.stopPropagation()
+                const event = events.value.find(ev => ev.id === eventId)
+                if (event) {
+                    // FullCalendarのEventオブジェクト形式に変換
+                    const fcEvent = {
+                        id: event.id,
+                        title: event.title,
+                        start: event.start,
+                        end: event.end,
+                        backgroundColor: event.backgroundColor,
+                        borderColor: event.borderColor,
+                        extendedProps: event.extendedProps,
+                    }
+                    handleEventClick({ event: fcEvent })
+                }
+            })
+        }
+    })
+}
+
 // FullCalendarの設定
 const calendarOptions = computed(() => ({
     plugins: [dayGridPlugin, interactionPlugin],
@@ -146,6 +174,7 @@ const calendarOptions = computed(() => ({
     dateClick: handleDateClick,
     eventClick: handleEventClick,
     dayCellContent: dayCellContent, // カスタム日付セルコンテンツ
+    dayCellDidMount: dayCellDidMount, // 日付セルマウント後の処理
     dayMaxEvents: false, // カスタム表示のため無効化
 }))
 

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -144,16 +144,11 @@ const dayCellDidMount = (info) => {
         dayFrame.appendChild(contentContainer)
     }
     
-    // データがない場合は空のコンテナだけ追加して終了
-    if (!dayData || (dayData.schedules.length === 0 && dayData.residents.size === 0)) {
-        return
-    }
-    
-    // スケジュールセクション
+    // スケジュールセクション（上半分）- 常に作成
     const schedulesSection = document.createElement('div')
     schedulesSection.className = 'schedules-section'
     
-    if (dayData.schedules.length > 0) {
+    if (dayData && dayData.schedules.length > 0) {
         dayData.schedules.forEach(schedule => {
             const scheduleItem = document.createElement('div')
             scheduleItem.className = 'calendar-schedule-item'
@@ -190,37 +185,35 @@ const dayCellDidMount = (info) => {
         })
     }
     
-    // スケジュールセクションを追加（常に追加）
-    contentContainer.appendChild(schedulesSection)
+    // 入浴予定者セクション（下半分）- 常に作成
+    const residentsSection = document.createElement('div')
+    residentsSection.className = 'calendar-residents-section'
     
-    // 入浴予定者セクション（下半分）
-    if (dayData.residents.size > 0) {
-        const residentsSection = document.createElement('div')
-        residentsSection.className = 'calendar-residents-section'
-        
-        const labelDiv = document.createElement('div')
-        labelDiv.className = 'residents-label'
-        labelDiv.textContent = '入浴予定者'
-        
-        const listDiv = document.createElement('div')
-        listDiv.className = 'residents-list'
+    const labelDiv = document.createElement('div')
+    labelDiv.className = 'residents-label'
+    labelDiv.textContent = '入浴予定者'
+    
+    const listDiv = document.createElement('div')
+    listDiv.className = 'residents-list'
+    
+    if (dayData && dayData.residents.size > 0) {
         const residentsList = Array.from(dayData.residents).map(residentId => {
             const resident = residents.value.find(r => r.id === residentId)
             return resident ? resident.name : ''
         }).filter(Boolean)
         listDiv.textContent = residentsList.join(', ')
-        
-        residentsSection.appendChild(labelDiv)
-        residentsSection.appendChild(listDiv)
-        
-        contentContainer.appendChild(residentsSection)
     } else {
-        // 入浴予定者がいない場合でも、下半分のスペースを確保
-        const emptyResidentsSection = document.createElement('div')
-        emptyResidentsSection.className = 'calendar-residents-section'
-        emptyResidentsSection.style.minHeight = '50px'
-        contentContainer.appendChild(emptyResidentsSection)
+        listDiv.textContent = 'なし'
+        listDiv.style.color = '#9ca3af'
+        listDiv.style.fontStyle = 'italic'
     }
+    
+    residentsSection.appendChild(labelDiv)
+    residentsSection.appendChild(listDiv)
+    
+    // 両方のセクションを常に追加
+    contentContainer.appendChild(schedulesSection)
+    contentContainer.appendChild(residentsSection)
 }
 
 // FullCalendarの設定
@@ -398,12 +391,13 @@ const closeScheduleModal = () => {
 
 /* スケジュールセクション（上半分） */
 :deep(.schedules-section) {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
+    flex: 1 1 50% !important;
+    display: flex !important;
+    flex-direction: column !important;
     gap: 2px;
     overflow-y: auto;
-    min-height: 0;
+    min-height: 60px !important;
+    max-height: none;
     border-bottom: 2px solid #e5e7eb;
     padding-bottom: 4px;
     margin-bottom: 4px;
@@ -439,8 +433,11 @@ const closeScheduleModal = () => {
 
 /* 入浴予定者セクション（下半分） */
 :deep(.calendar-residents-section) {
-    flex-shrink: 0;
-    min-height: 50px;
+    flex: 1 1 50% !important;
+    display: flex !important;
+    flex-direction: column !important;
+    min-height: 50px !important;
+    max-height: none;
     padding-top: 4px;
 }
 

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -35,15 +35,14 @@ const showScheduleModal = ref(false);
 const selectedSchedule = ref(null);
 
 // props.eventsの変更を監視してeventsを更新
+// props.eventsの変更を監視してeventsを更新
 watch(
     () => props.events,
     (newEvents) => {
-        console.log("Watcher: props.events changed", newEvents?.length);
         if (newEvents) {
             events.value = newEvents;
             // コンポーネントを再生成して完全にリセット
             calendarKey.value++;
-            console.log("Watcher: incremented calendarKey to", calendarKey.value);
         }
     },
     { deep: true }
@@ -113,7 +112,6 @@ const handleEventClick = (info) => {
 
 // 日付ごとにスケジュールと入浴予定者をグループ化
 const eventsByDate = computed(() => {
-    console.log("Computed: eventsByDate recalculating", events.value?.length);
     const grouped = {};
     
     if (!events.value || events.value.length === 0) {
@@ -124,8 +122,6 @@ const eventsByDate = computed(() => {
         if (!event.start) return;
         
         const date = dayjs(event.start).format("YYYY-MM-DD");
-        // デバッグ: 全イベントの日付変換ログ
-        console.log(`Event[${index}] id=${event.id} start=${event.start} -> date=${date}`);
         
         if (!grouped[date]) {
             grouped[date] = {
@@ -138,7 +134,6 @@ const eventsByDate = computed(() => {
             grouped[date].residents.add(event.extendedProps.resident_id);
         }
     });
-    console.log("Computed: eventsByDate keys:", Object.keys(grouped));
     return grouped;
 });
 
@@ -146,16 +141,6 @@ const eventsByDate = computed(() => {
 const renderDayCellContent = (info) => {
     const dateStr = dayjs(info.date).format("YYYY-MM-DD");
     const dayData = eventsByDate.value[dateStr];
-    
-    // 特定の日付（例：イベントがあるはずの日）でログを出力
-    if (dayData) {
-        console.log(`Render: Found data for ${dateStr}:`, dayData.schedules.length, "schedules");
-    } else {
-        // データがない場合も、特定の日付（例：4日）だけログ出す
-        if (dateStr.endsWith("-04") || dateStr.endsWith("-02")) {
-             console.log(`Render: No data for ${dateStr}`);
-        }
-    }
     
     const isToday = dateStr === dayjs().format("YYYY-MM-DD");
     const isDarkMode = document.documentElement.classList.contains("dark");
@@ -316,7 +301,6 @@ const calendarOptions = computed(() => ({
 
 // スケジュール作成成功時の処理
 const handleScheduleCreated = (newEvent) => {
-    console.log("handleScheduleCreated called", newEvent);
 
     if (newEvent) {
         // 作成されたスケジュールの日付を取得
@@ -326,7 +310,6 @@ const handleScheduleCreated = (newEvent) => {
 
         // 作成されたイベントを直接eventsに追加
         events.value = [...events.value, newEvent];
-        console.log("Added new event to events.value:", events.value.length);
 
         // FullCalendarのイベントを更新
         if (calendarRef.value) {
@@ -370,7 +353,6 @@ const handleScheduleUpdated = () => {
 
 // スケジュール削除成功時の処理
 const handleScheduleDeleted = (deletedScheduleId) => {
-    console.log("handleScheduleDeleted called", deletedScheduleId);
 
     // まずモーダルを閉じる（確実に閉じるため）
     closeScheduleModal();
@@ -390,10 +372,6 @@ const handleScheduleDeleted = (deletedScheduleId) => {
         // 削除されたスケジュールをeventsから直接削除
         events.value = events.value.filter(
             (event) => event.id !== deletedScheduleId
-        );
-        console.log(
-            "Removed deleted event from events.value:",
-            events.value.length
         );
 
         // FullCalendarのイベントを更新
@@ -446,7 +424,7 @@ const closeScheduleModal = () => {
                         <h1 class="text-2xl font-bold mb-6">カレンダー</h1>
 
                         <!-- デバッグ用セクション -->
-                        <div class="mb-4 p-4 bg-yellow-100 border border-yellow-400 rounded text-sm text-black">
+                        <!-- <div class="mb-4 p-4 bg-yellow-100 border border-yellow-400 rounded text-sm text-black">
                             <h3 class="font-bold mb-2">デバッグ情報</h3>
                             <div class="grid grid-cols-2 gap-2">
                                 <div>Events Length: {{ events.length }}</div>
@@ -465,7 +443,7 @@ const closeScheduleModal = () => {
                             <div class="mt-2 text-xs text-gray-600">
                                 <p>Events Sample: {{ events.length > 0 ? JSON.stringify(events[0]).substring(0, 100) + '...' : 'None' }}</p>
                             </div>
-                        </div>
+                        </div> -->
 
                         <!-- カレンダー表示 -->
                         <div class="calendar-container">

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -134,7 +134,7 @@ const dayCellDidMount = (info) => {
     
     // カスタムコンテンツコンテナを作成
     const contentContainer = document.createElement('div')
-    contentContainer.className = 'custom-day-content'
+    contentContainer.className = 'flex-1 flex flex-col p-1 gap-1 min-h-0 overflow-hidden w-full'
     
     // .fc-daygrid-day-numberの後に挿入
     const dayNumberEl = dayFrame.querySelector('.fc-daygrid-day-number')
@@ -146,21 +146,21 @@ const dayCellDidMount = (info) => {
     
     // スケジュールセクション（上半分）- 常に作成
     const schedulesSection = document.createElement('div')
-    schedulesSection.className = 'schedules-section'
+    schedulesSection.className = 'flex flex-col gap-0.5 overflow-y-auto min-h-[60px] flex-1 border-b-4 border-gray-400 pb-2 mb-2 bg-gray-50'
     
     if (dayData && dayData.schedules.length > 0) {
         dayData.schedules.forEach(schedule => {
             const scheduleItem = document.createElement('div')
-            scheduleItem.className = 'calendar-schedule-item'
+            scheduleItem.className = 'flex items-center gap-1 px-1 py-0.5 rounded text-sm text-white cursor-pointer hover:opacity-80'
             scheduleItem.style.backgroundColor = schedule.backgroundColor || '#3B82F6'
             scheduleItem.setAttribute('data-event-id', schedule.id)
             
             const timeSpan = document.createElement('span')
-            timeSpan.className = 'schedule-time'
+            timeSpan.className = 'font-bold whitespace-nowrap'
             timeSpan.textContent = dayjs(schedule.start).format('HH:mm')
             
             const titleSpan = document.createElement('span')
-            titleSpan.className = 'schedule-title'
+            titleSpan.className = 'flex-1 overflow-hidden text-ellipsis whitespace-nowrap'
             titleSpan.textContent = schedule.extendedProps?.schedule_type_name || schedule.title
             
             scheduleItem.appendChild(timeSpan)
@@ -187,25 +187,24 @@ const dayCellDidMount = (info) => {
     
     // 入浴予定者セクション（下半分）- 常に作成
     const residentsSection = document.createElement('div')
-    residentsSection.className = 'calendar-residents-section'
+    residentsSection.className = 'flex flex-col min-h-[50px] flex-1 border-t-4 border-gray-400 pt-2 bg-gray-100'
     
     const labelDiv = document.createElement('div')
-    labelDiv.className = 'residents-label'
+    labelDiv.className = 'text-xs font-bold text-gray-600 mb-0.5'
     labelDiv.textContent = '入浴予定者'
     
     const listDiv = document.createElement('div')
-    listDiv.className = 'residents-list'
     
     if (dayData && dayData.residents.size > 0) {
+        listDiv.className = 'text-sm text-gray-700 leading-relaxed break-words'
         const residentsList = Array.from(dayData.residents).map(residentId => {
             const resident = residents.value.find(r => r.id === residentId)
             return resident ? resident.name : ''
         }).filter(Boolean)
         listDiv.textContent = residentsList.join(', ')
     } else {
+        listDiv.className = 'text-sm text-gray-400 italic'
         listDiv.textContent = 'なし'
-        listDiv.style.color = '#9ca3af'
-        listDiv.style.fontStyle = 'italic'
     }
     
     residentsSection.appendChild(labelDiv)

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -62,6 +62,7 @@ const handleEventClick = (info) => {
 // 日付ごとにスケジュールと入浴予定者をグループ化
 const eventsByDate = computed(() => {
     const grouped = {}
+    console.log('eventsByDate computed - events.value:', events.value)
     events.value.forEach(event => {
         const date = dayjs(event.start).format('YYYY-MM-DD')
         if (!grouped[date]) {
@@ -75,6 +76,7 @@ const eventsByDate = computed(() => {
             grouped[date].residents.add(event.extendedProps.resident_id)
         }
     })
+    console.log('eventsByDate computed - grouped:', grouped)
     return grouped
 })
 
@@ -82,6 +84,8 @@ const eventsByDate = computed(() => {
 const dayCellContent = (info) => {
     const dateStr = dayjs(info.date).format('YYYY-MM-DD')
     const dayData = eventsByDate.value[dateStr]
+    
+    console.log('dayCellContent called for date:', dateStr, 'dayData:', dayData)
     
     // スケジュールセクション
     const schedulesHtml = dayData && dayData.schedules.length > 0
@@ -111,15 +115,17 @@ const dayCellContent = (info) => {
         </div>`
         : ''
     
-    return {
-        html: `<div class="custom-day-cell">
-            <div class="day-number">${info.dayNumberText}</div>
-            <div class="day-content">
-                <div class="schedules-section">${schedulesHtml}</div>
-                ${residentsHtml}
-            </div>
-        </div>`
-    }
+    const html = `<div class="custom-day-cell">
+        <div class="day-number">${info.dayNumberText}</div>
+        <div class="day-content">
+            <div class="schedules-section">${schedulesHtml}</div>
+            ${residentsHtml}
+        </div>
+    </div>`
+    
+    console.log('dayCellContent returning html for', dateStr, ':', html.substring(0, 100))
+    
+    return { html }
 }
 
 // 日付セルがマウントされた後にクリックイベントをバインド

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -1,174 +1,191 @@
 <script setup>
-import { ref, computed } from 'vue'
-import { Head, usePage, router } from '@inertiajs/vue3'
-import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
-import FullCalendar from '@fullcalendar/vue3'
-import dayGridPlugin from '@fullcalendar/daygrid'
-import interactionPlugin from '@fullcalendar/interaction'
-import dayjs from 'dayjs'
-import 'dayjs/locale/ja'
-import jaLocale from '@fullcalendar/core/locales/ja.js'
-import ScheduleForm from '@/Components/ScheduleForm.vue'
-import ScheduleModal from '@/Components/ScheduleModal.vue'
+import { ref, computed } from "vue";
+import { Head, usePage, router } from "@inertiajs/vue3";
+import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
+import FullCalendar from "@fullcalendar/vue3";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import interactionPlugin from "@fullcalendar/interaction";
+import dayjs from "dayjs";
+import "dayjs/locale/ja";
+import jaLocale from "@fullcalendar/core/locales/ja.js";
+import ScheduleForm from "@/Components/ScheduleForm.vue";
+import ScheduleModal from "@/Components/ScheduleModal.vue";
 
-dayjs.locale('ja')
+dayjs.locale("ja");
 
-const { props } = usePage()
+const { props } = usePage();
 
-const events = ref(props.events || [])
-const residents = ref(props.residents || [])
-const scheduleTypes = ref(props.scheduleTypes || [])
-const monthStats = ref(props.monthStats || { total: 0, by_type: {} })
-const currentDate = ref(props.currentDate || dayjs().format('YYYY-MM-DD'))
+const events = ref(props.events || []);
+const residents = ref(props.residents || []);
+const scheduleTypes = ref(props.scheduleTypes || []);
+const monthStats = ref(props.monthStats || { total: 0, by_type: {} });
+const currentDate = ref(props.currentDate || dayjs().format("YYYY-MM-DD"));
 
 // デバッグ: 初期データを確認
-console.log('Initial props:', props)
-console.log('Initial events:', events.value)
-console.log('Initial residents:', residents.value)
+console.log("Initial props:", props);
+console.log("Initial events:", events.value);
+console.log("Initial residents:", residents.value);
 
 // スケジュール作成フォームの表示状態
-const showScheduleForm = ref(false)
-const formInitialDate = ref(null)
-const formInitialResidentId = ref(null)
+const showScheduleForm = ref(false);
+const formInitialDate = ref(null);
+const formInitialResidentId = ref(null);
 
 // スケジュール詳細モーダルの表示状態
-const showScheduleModal = ref(false)
-const selectedSchedule = ref(null)
+const showScheduleModal = ref(false);
+const selectedSchedule = ref(null);
 
 // カレンダーの月変更時の処理
 const handleMonthChange = (info) => {
     // 月が変更された場合、新しい月のデータを取得
-    const newDate = dayjs(info.start).format('YYYY-MM-DD')
-    const monthStart = dayjs(currentDate.value).startOf('month').format('YYYY-MM-DD')
-    const newMonthStart = dayjs(info.start).startOf('month').format('YYYY-MM-DD')
-    
+    const newDate = dayjs(info.start).format("YYYY-MM-DD");
+    const monthStart = dayjs(currentDate.value)
+        .startOf("month")
+        .format("YYYY-MM-DD");
+    const newMonthStart = dayjs(info.start)
+        .startOf("month")
+        .format("YYYY-MM-DD");
+
     if (newMonthStart !== monthStart) {
         // Inertiaでページを再読み込み
-        router.get(route('calendar.index'), { date: newDate }, {
-            preserveState: true,
-            preserveScroll: true,
-        })
+        router.get(
+            route("calendar.index"),
+            { date: newDate },
+            {
+                preserveState: true,
+                preserveScroll: true,
+            }
+        );
     }
-}
+};
 
 // 日付クリック時の処理
 const handleDateClick = (info) => {
-    formInitialDate.value = dayjs(info.date).format('YYYY-MM-DD')
-    formInitialResidentId.value = null
-    showScheduleForm.value = true
-}
+    formInitialDate.value = dayjs(info.date).format("YYYY-MM-DD");
+    formInitialResidentId.value = null;
+    showScheduleForm.value = true;
+};
 
 // イベントクリック時の処理
 const handleEventClick = (info) => {
-    selectedSchedule.value = info.event
-    showScheduleModal.value = true
-}
+    selectedSchedule.value = info.event;
+    showScheduleModal.value = true;
+};
 
 // 日付ごとにスケジュールと入浴予定者をグループ化
 const eventsByDate = computed(() => {
-    const grouped = {}
-    console.log('eventsByDate computed - events.value:', events.value)
-    console.log('eventsByDate computed - events.value.length:', events.value?.length)
-    
+    const grouped = {};
+    console.log("eventsByDate computed - events.value:", events.value);
+    console.log(
+        "eventsByDate computed - events.value.length:",
+        events.value?.length
+    );
+
     if (!events.value || events.value.length === 0) {
-        console.warn('events.value is empty or undefined')
-        return grouped
+        console.warn("events.value is empty or undefined");
+        return grouped;
     }
-    
+
     events.value.forEach((event, index) => {
-        console.log(`Processing event ${index}:`, event)
+        console.log(`Processing event ${index}:`, event);
         if (!event.start) {
-            console.warn(`Event ${index} has no start date:`, event)
-            return
+            console.warn(`Event ${index} has no start date:`, event);
+            return;
         }
-        const date = dayjs(event.start).format('YYYY-MM-DD')
-        console.log(`Event ${index} date:`, date)
+        const date = dayjs(event.start).format("YYYY-MM-DD");
+        console.log(`Event ${index} date:`, date);
         if (!grouped[date]) {
             grouped[date] = {
                 schedules: [],
-                residents: new Set()
-            }
+                residents: new Set(),
+            };
         }
-        grouped[date].schedules.push(event)
+        grouped[date].schedules.push(event);
         if (event.extendedProps?.resident_id) {
-            grouped[date].residents.add(event.extendedProps.resident_id)
+            grouped[date].residents.add(event.extendedProps.resident_id);
         }
-    })
-    console.log('eventsByDate computed - grouped:', grouped)
-    return grouped
-})
+    });
+    console.log("eventsByDate computed - grouped:", grouped);
+    return grouped;
+});
 
 // 日付セルのカスタムコンテンツ（日付番号のみを返す）
 const dayCellContent = (info) => {
     // 日付番号のみを返し、コンテンツはdayCellDidMountで追加
-    return info.dayNumberText
-}
+    return info.dayNumberText;
+};
 
 // 日付セルがマウントされた後にコンテンツを追加
 const dayCellDidMount = (info) => {
-    const dateStr = dayjs(info.date).format('YYYY-MM-DD')
-    const dayData = eventsByDate.value[dateStr]
-    
+    const dateStr = dayjs(info.date).format("YYYY-MM-DD");
+    const dayData = eventsByDate.value[dateStr];
+
     // FullCalendarのDOM構造:
     // .fc-daygrid-day
     //   .fc-daygrid-day-frame
     //     .fc-daygrid-day-number (日付番号)
     //     .fc-daygrid-day-events (デフォルトイベントコンテナ - 非表示にする)
     //     .fc-daygrid-day-bg (背景)
-    
+
     // .fc-daygrid-day-frameを取得
-    const dayFrame = info.el.querySelector('.fc-daygrid-day-frame')
-    if (!dayFrame) return
-    
+    const dayFrame = info.el.querySelector(".fc-daygrid-day-frame");
+    if (!dayFrame) return;
+
     // デフォルトのイベント表示を非表示にする
-    const dayEvents = dayFrame.querySelector('.fc-daygrid-day-events')
+    const dayEvents = dayFrame.querySelector(".fc-daygrid-day-events");
     if (dayEvents) {
-        dayEvents.style.display = 'none'
+        dayEvents.style.display = "none";
     }
-    
+
     // 既存のカスタムコンテンツを削除
-    const existingContent = dayFrame.querySelector('.custom-day-content')
+    const existingContent = dayFrame.querySelector(".custom-day-content");
     if (existingContent) {
-        existingContent.remove()
+        existingContent.remove();
     }
-    
+
     // カスタムコンテンツコンテナを作成
-    const contentContainer = document.createElement('div')
-    contentContainer.className = 'flex-1 flex flex-col p-1 gap-1 min-h-0 overflow-hidden w-full'
-    
+    const contentContainer = document.createElement("div");
+    contentContainer.className =
+        "flex-1 flex flex-col p-1 gap-1 min-h-0 overflow-hidden w-full";
+
     // .fc-daygrid-day-numberの後に挿入
-    const dayNumberEl = dayFrame.querySelector('.fc-daygrid-day-number')
+    const dayNumberEl = dayFrame.querySelector(".fc-daygrid-day-number");
     if (dayNumberEl && dayNumberEl.nextSibling) {
-        dayFrame.insertBefore(contentContainer, dayNumberEl.nextSibling)
+        dayFrame.insertBefore(contentContainer, dayNumberEl.nextSibling);
     } else {
-        dayFrame.appendChild(contentContainer)
+        dayFrame.appendChild(contentContainer);
     }
-    
+
     // スケジュールセクション（上半分）- 常に作成
-    const schedulesSection = document.createElement('div')
-    schedulesSection.className = 'flex flex-col gap-0.5 overflow-y-auto min-h-[60px] flex-1 border-b-4 border-gray-400 pb-2 mb-2 bg-gray-50'
-    
+    const schedulesSection = document.createElement("div");
+    schedulesSection.className =
+        "flex flex-col gap-0.5 overflow-y-auto min-h-[60px] flex-1 border-b-4 border-gray-400 pb-2 mb-2 bg-gray-50";
+
     if (dayData && dayData.schedules.length > 0) {
-        dayData.schedules.forEach(schedule => {
-            const scheduleItem = document.createElement('div')
-            scheduleItem.className = 'flex items-center gap-1 px-1 py-0.5 rounded text-sm text-white cursor-pointer hover:opacity-80'
-            scheduleItem.style.backgroundColor = schedule.backgroundColor || '#3B82F6'
-            scheduleItem.setAttribute('data-event-id', schedule.id)
-            
-            const timeSpan = document.createElement('span')
-            timeSpan.className = 'font-bold whitespace-nowrap'
-            timeSpan.textContent = dayjs(schedule.start).format('HH:mm')
-            
-            const titleSpan = document.createElement('span')
-            titleSpan.className = 'flex-1 overflow-hidden text-ellipsis whitespace-nowrap'
-            titleSpan.textContent = schedule.extendedProps?.schedule_type_name || schedule.title
-            
-            scheduleItem.appendChild(timeSpan)
-            scheduleItem.appendChild(titleSpan)
-            
+        dayData.schedules.forEach((schedule) => {
+            const scheduleItem = document.createElement("div");
+            scheduleItem.className =
+                "flex items-center gap-1 px-1 py-0.5 rounded text-sm text-white cursor-pointer hover:opacity-80";
+            scheduleItem.style.backgroundColor =
+                schedule.backgroundColor || "#3B82F6";
+            scheduleItem.setAttribute("data-event-id", schedule.id);
+
+            const timeSpan = document.createElement("span");
+            timeSpan.className = "font-bold whitespace-nowrap";
+            timeSpan.textContent = dayjs(schedule.start).format("HH:mm");
+
+            const titleSpan = document.createElement("span");
+            titleSpan.className =
+                "flex-1 overflow-hidden text-ellipsis whitespace-nowrap";
+            titleSpan.textContent =
+                schedule.extendedProps?.schedule_type_name || schedule.title;
+
+            scheduleItem.appendChild(timeSpan);
+            scheduleItem.appendChild(titleSpan);
+
             // クリックイベントをバインド
-            scheduleItem.addEventListener('click', (e) => {
-                e.stopPropagation()
+            scheduleItem.addEventListener("click", (e) => {
+                e.stopPropagation();
                 const fcEvent = {
                     id: schedule.id,
                     title: schedule.title,
@@ -177,63 +194,68 @@ const dayCellDidMount = (info) => {
                     backgroundColor: schedule.backgroundColor,
                     borderColor: schedule.borderColor,
                     extendedProps: schedule.extendedProps,
-                }
-                handleEventClick({ event: fcEvent })
-            })
-            
-            schedulesSection.appendChild(scheduleItem)
-        })
+                };
+                handleEventClick({ event: fcEvent });
+            });
+
+            schedulesSection.appendChild(scheduleItem);
+        });
     }
-    
+
     // 入浴予定者セクション（下半分）- 常に作成
-    const residentsSection = document.createElement('div')
-    residentsSection.className = 'flex flex-col min-h-[50px] flex-1 border-t-4 border-gray-400 pt-2 bg-gray-100'
-    
-    const labelDiv = document.createElement('div')
-    labelDiv.className = 'text-xs font-bold text-gray-600 mb-0.5'
-    labelDiv.textContent = '入浴予定者'
-    
-    const listDiv = document.createElement('div')
-    
+    const residentsSection = document.createElement("div");
+    residentsSection.className =
+        "flex flex-col min-h-[50px] flex-1 border-t-4 border-gray-400 pt-2 bg-gray-100";
+
+    const labelDiv = document.createElement("div");
+    labelDiv.className = "text-xs font-bold text-gray-600 mb-0.5";
+    labelDiv.textContent = "入浴予定者";
+
+    const listDiv = document.createElement("div");
+
     if (dayData && dayData.residents.size > 0) {
-        listDiv.className = 'text-sm text-gray-700 leading-relaxed break-words'
-        const residentsList = Array.from(dayData.residents).map(residentId => {
-            const resident = residents.value.find(r => r.id === residentId)
-            return resident ? resident.name : ''
-        }).filter(Boolean)
-        listDiv.textContent = residentsList.join(', ')
+        listDiv.className = "text-sm text-gray-700 leading-relaxed break-words";
+        const residentsList = Array.from(dayData.residents)
+            .map((residentId) => {
+                const resident = residents.value.find(
+                    (r) => r.id === residentId
+                );
+                return resident ? resident.name : "";
+            })
+            .filter(Boolean);
+        listDiv.textContent = residentsList.join(", ");
     } else {
-        listDiv.className = 'text-sm text-gray-400 italic'
-        listDiv.textContent = 'なし'
+        listDiv.className = "text-sm text-gray-400 italic";
+        listDiv.textContent = "なし";
     }
-    
-    residentsSection.appendChild(labelDiv)
-    residentsSection.appendChild(listDiv)
-    
+
+    residentsSection.appendChild(labelDiv);
+    residentsSection.appendChild(listDiv);
+
     // 両方のセクションを常に追加
-    contentContainer.appendChild(schedulesSection)
-    contentContainer.appendChild(residentsSection)
-}
+    contentContainer.appendChild(schedulesSection);
+    contentContainer.appendChild(residentsSection);
+};
 
 // FullCalendarの設定
 const calendarOptions = computed(() => ({
     plugins: [dayGridPlugin, interactionPlugin],
-    initialView: 'dayGridMonth',
+    initialView: "dayGridMonth",
     locale: jaLocale,
     headerToolbar: {
-        left: 'prev,next today',
-        center: 'title',
-        right: '',
+        left: "prev,next today",
+        center: "title",
+        right: "",
     },
     buttonText: {
-        today: '今日',
-        month: '月',
-        week: '週',
-        day: '日',
+        today: "今日",
+        month: "月",
+        week: "週",
+        day: "日",
     },
     events: events.value,
-    eventDisplay: 'none', // カスタム表示のため標準イベント表示を無効化
-    height: 'auto',
+    eventDisplay: "none", // カスタム表示のため標準イベント表示を無効化
+    height: "auto",
     editable: false,
     selectable: false,
     dateClick: handleDateClick,
@@ -241,38 +263,38 @@ const calendarOptions = computed(() => ({
     dayCellContent: dayCellContent, // カスタム日付セルコンテンツ
     dayCellDidMount: dayCellDidMount, // 日付セルマウント後の処理
     dayMaxEvents: false, // カスタム表示のため無効化
-}))
+}));
 
 // スケジュール作成成功時の処理
 const handleScheduleCreated = () => {
     // カレンダーを再読み込み
-    router.reload({ only: ['events', 'monthStats'] })
-}
+    router.reload({ only: ["events", "monthStats"] });
+};
 
 // フォームを閉じる
 const closeScheduleForm = () => {
-    showScheduleForm.value = false
-    formInitialDate.value = null
-    formInitialResidentId.value = null
-}
+    showScheduleForm.value = false;
+    formInitialDate.value = null;
+    formInitialResidentId.value = null;
+};
 
 // スケジュール更新成功時の処理
 const handleScheduleUpdated = () => {
     // カレンダーを再読み込み
-    router.reload({ only: ['events', 'monthStats'] })
-}
+    router.reload({ only: ["events", "monthStats"] });
+};
 
 // スケジュール削除成功時の処理
 const handleScheduleDeleted = () => {
     // カレンダーを再読み込み
-    router.reload({ only: ['events', 'monthStats'] })
-}
+    router.reload({ only: ["events", "monthStats"] });
+};
 
 // モーダルを閉じる
 const closeScheduleModal = () => {
-    showScheduleModal.value = false
-    selectedSchedule.value = null
-}
+    showScheduleModal.value = false;
+    selectedSchedule.value = null;
+};
 </script>
 
 <template>
@@ -281,28 +303,47 @@ const closeScheduleModal = () => {
 
         <div class="py-12">
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div
+                    class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg"
+                >
                     <div class="p-6 text-gray-900 dark:text-gray-100">
                         <h1 class="text-2xl font-bold mb-6">カレンダー</h1>
 
                         <!-- カレンダー表示 -->
                         <div class="calendar-container">
-                            <FullCalendar :options="calendarOptions" @datesSet="handleMonthChange" />
+                            <FullCalendar
+                                :options="calendarOptions"
+                                @datesSet="handleMonthChange"
+                            />
                         </div>
 
                         <!-- 月間統計情報 -->
                         <div class="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
-                            <div class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg">
-                                <div class="text-sm text-gray-600 dark:text-gray-400">総スケジュール数</div>
-                                <div class="text-2xl font-bold">{{ monthStats.total }}</div>
+                            <div
+                                class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg"
+                            >
+                                <div
+                                    class="text-sm text-gray-600 dark:text-gray-400"
+                                >
+                                    総スケジュール数
+                                </div>
+                                <div class="text-2xl font-bold">
+                                    {{ monthStats.total }}
+                                </div>
                             </div>
                             <div
                                 v-for="type in scheduleTypes"
                                 :key="type.id"
                                 class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg"
                             >
-                                <div class="text-sm text-gray-600 dark:text-gray-400">{{ type.name }}</div>
-                                <div class="text-2xl font-bold">{{ monthStats.by_type[type.id] || 0 }}</div>
+                                <div
+                                    class="text-sm text-gray-600 dark:text-gray-400"
+                                >
+                                    {{ type.name }}
+                                </div>
+                                <div class="text-2xl font-bold">
+                                    {{ monthStats.by_type[type.id] || 0 }}
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -406,7 +447,7 @@ const closeScheduleModal = () => {
 
 /* 分割線をより明確にするための疑似要素 */
 :deep(.schedules-section::after) {
-    content: '';
+    content: "";
     position: absolute;
     bottom: -4px;
     left: 0;
@@ -460,7 +501,7 @@ const closeScheduleModal = () => {
 
 /* 分割線をより明確にするための疑似要素 */
 :deep(.calendar-residents-section::before) {
-    content: '';
+    content: "";
     position: absolute;
     top: -4px;
     left: 0;
@@ -519,4 +560,3 @@ const closeScheduleModal = () => {
     color: white;
 }
 </style>
-

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -334,39 +334,53 @@ const closeScheduleModal = () => {
     min-height: 150px;
 }
 
-/* カスタム日付セル */
-:deep(.custom-day-cell) {
+/* FullCalendarの日付セルを上下2分割にする */
+:deep(.fc-daygrid-day-frame) {
     display: flex;
     flex-direction: column;
     height: 100%;
     min-height: 150px;
 }
 
-:deep(.day-number) {
+:deep(.fc-daygrid-day) {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 150px;
+}
+
+/* 日付番号部分 */
+:deep(.fc-daygrid-day-number) {
     font-weight: bold;
     font-size: 1.1rem;
     padding: 4px 8px;
     border-bottom: 1px solid #e5e7eb;
     background-color: #f9fafb;
+    flex-shrink: 0;
 }
 
-:deep(.day-content) {
+/* カスタムコンテンツコンテナ */
+:deep(.custom-day-content) {
     flex: 1;
     display: flex;
     flex-direction: column;
     padding: 4px;
     gap: 4px;
+    min-height: 0;
+    overflow: hidden;
 }
 
-/* スケジュールセクション */
+/* スケジュールセクション（上半分） */
 :deep(.schedules-section) {
     flex: 1;
     display: flex;
     flex-direction: column;
     gap: 2px;
     overflow-y: auto;
-    min-height: 60px;
-    max-height: 80px;
+    min-height: 0;
+    border-bottom: 2px solid #e5e7eb;
+    padding-bottom: 4px;
+    margin-bottom: 4px;
 }
 
 :deep(.calendar-schedule-item) {
@@ -397,12 +411,11 @@ const closeScheduleModal = () => {
     white-space: nowrap;
 }
 
-/* 入浴予定者セクション */
+/* 入浴予定者セクション（下半分） */
 :deep(.calendar-residents-section) {
-    border-top: 2px solid #e5e7eb;
-    padding-top: 4px;
-    margin-top: 4px;
+    flex-shrink: 0;
     min-height: 50px;
+    padding-top: 4px;
 }
 
 :deep(.residents-label) {

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -352,50 +352,48 @@ const closeScheduleModal = () => {
     font-size: 1.1rem;
 }
 
-:deep(.fc-daygrid-day-frame) {
-    min-height: 150px;
-    height: auto;
-}
-
-:deep(.fc-daygrid-day) {
-    height: auto;
-    min-height: 150px;
-}
-
 /* FullCalendarの日付セルを上下2分割にする */
+/* .fc-daygrid-day-frameはFullCalendarが自動生成するフレーム要素 */
 :deep(.fc-daygrid-day-frame) {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    min-height: 150px;
+    display: flex !important;
+    flex-direction: column !important;
+    height: 100% !important;
+    min-height: 150px !important;
+    position: relative;
 }
 
 :deep(.fc-daygrid-day) {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
+    height: auto;
     min-height: 150px;
 }
 
-/* 日付番号部分 */
+/* 日付番号部分 - 上部に固定 */
 :deep(.fc-daygrid-day-number) {
     font-weight: bold;
     font-size: 1.1rem;
     padding: 4px 8px;
     border-bottom: 1px solid #e5e7eb;
     background-color: #f9fafb;
-    flex-shrink: 0;
+    flex-shrink: 0 !important;
+    order: 1;
 }
 
-/* カスタムコンテンツコンテナ */
+/* デフォルトのイベント表示を非表示 */
+:deep(.fc-daygrid-day-events) {
+    display: none !important;
+}
+
+/* カスタムコンテンツコンテナ - 日付番号の下に配置 */
 :deep(.custom-day-content) {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
+    flex: 1 !important;
+    display: flex !important;
+    flex-direction: column !important;
     padding: 4px;
     gap: 4px;
     min-height: 0;
     overflow: hidden;
+    order: 2;
+    width: 100%;
 }
 
 /* スケジュールセクション（上半分） */

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch, nextTick } from "vue";
+import { ref, computed, watch, nextTick, onMounted } from "vue";
 import { Head, usePage, router } from "@inertiajs/vue3";
 import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
 import FullCalendar from "@fullcalendar/vue3";
@@ -23,69 +23,7 @@ const currentDate = ref(props.currentDate || dayjs().format("YYYY-MM-DD"));
 
 // FullCalendarのref
 const calendarRef = ref(null);
-
-// propsの変更を監視してrefを更新
-watch(
-    () => props.events,
-    (newEvents, oldEvents) => {
-        console.log("props.events changed:", {
-            oldLength: oldEvents?.length || 0,
-            newLength: newEvents?.length || 0,
-            oldEvents: oldEvents,
-            newEvents: newEvents,
-        });
-        if (newEvents) {
-            // 配列の参照を変更して確実に更新
-            events.value = [...newEvents];
-            console.log("events.value updated:", events.value.length);
-
-            // FullCalendarのイベントを更新
-            if (calendarRef.value) {
-                const calendarApi = calendarRef.value.getApi();
-                console.log(
-                    "Updating calendar events, current events:",
-                    calendarApi.getEvents().length
-                );
-
-                // すべてのイベントを削除
-                calendarApi.removeAllEvents();
-
-                // 新しいイベントを追加
-                if (Array.isArray(newEvents) && newEvents.length > 0) {
-                    newEvents.forEach((event) => {
-                        calendarApi.addEvent(event);
-                    });
-                }
-
-                // dayCellDidMountはeventsByDateが変更されると自動的に再実行されるため
-                // gotoDateを使わずにイベントの更新のみを行う
-
-                console.log(
-                    "Calendar updated, new events:",
-                    calendarApi.getEvents().length
-                );
-            } else {
-                console.warn("calendarRef.value is null");
-            }
-        }
-    },
-    { deep: true, immediate: false }
-);
-
-watch(
-    () => props.monthStats,
-    (newStats) => {
-        if (newStats) {
-            monthStats.value = newStats;
-        }
-    },
-    { deep: true }
-);
-
-// デバッグ: 初期データを確認
-console.log("Initial props:", props);
-console.log("Initial events:", events.value);
-console.log("Initial residents:", residents.value);
+const calendarKey = ref(0); // コンポーネント再生成用のキー
 
 // スケジュール作成フォームの表示状態
 const showScheduleForm = ref(false);
@@ -96,14 +34,38 @@ const formInitialResidentId = ref(null);
 const showScheduleModal = ref(false);
 const selectedSchedule = ref(null);
 
+// props.eventsの変更を監視してeventsを更新
+watch(
+    () => props.events,
+    (newEvents) => {
+        console.log("Watcher: props.events changed", newEvents?.length);
+        if (newEvents) {
+            events.value = newEvents;
+            // コンポーネントを再生成して完全にリセット
+            calendarKey.value++;
+            console.log("Watcher: incremented calendarKey to", calendarKey.value);
+        }
+    },
+    { deep: true }
+);
+
+// マウント時の処理
+onMounted(() => {
+    // 初期表示時も念のためキーを更新
+    // calendarKey.value++; 
+    // ↑ onMountedでの更新は不要かもしれないが、念のため
+});
+
 // カレンダーの月変更時の処理
 const handleMonthChange = (info) => {
     // 月が変更された場合、新しい月のデータを取得
-    const newDate = dayjs(info.start).format("YYYY-MM-DD");
+    // info.startはグリッドの開始日（前月の日付が含まれる場合がある）なので、
+    // info.view.currentStart（表示中の月の1日）を使用する
+    const newDate = dayjs(info.view.currentStart).format("YYYY-MM-DD");
     const monthStart = dayjs(currentDate.value)
         .startOf("month")
         .format("YYYY-MM-DD");
-    const newMonthStart = dayjs(info.start)
+    const newMonthStart = dayjs(info.view.currentStart)
         .startOf("month")
         .format("YYYY-MM-DD");
 
@@ -115,6 +77,7 @@ const handleMonthChange = (info) => {
             {
                 preserveState: true,
                 preserveScroll: true,
+                only: ["events", "residents", "monthStats", "currentDate"], // 必要なデータのみ取得
             }
         );
     }
@@ -150,26 +113,20 @@ const handleEventClick = (info) => {
 
 // 日付ごとにスケジュールと入浴予定者をグループ化
 const eventsByDate = computed(() => {
+    console.log("Computed: eventsByDate recalculating", events.value?.length);
     const grouped = {};
-    console.log("eventsByDate computed - events.value:", events.value);
-    console.log(
-        "eventsByDate computed - events.value.length:",
-        events.value?.length
-    );
-
+    
     if (!events.value || events.value.length === 0) {
-        console.warn("events.value is empty or undefined");
         return grouped;
     }
 
     events.value.forEach((event, index) => {
-        console.log(`Processing event ${index}:`, event);
-        if (!event.start) {
-            console.warn(`Event ${index} has no start date:`, event);
-            return;
-        }
+        if (!event.start) return;
+        
         const date = dayjs(event.start).format("YYYY-MM-DD");
-        console.log(`Event ${index} date:`, date);
+        // デバッグ: 全イベントの日付変換ログ
+        console.log(`Event[${index}] id=${event.id} start=${event.start} -> date=${date}`);
+        
         if (!grouped[date]) {
             grouped[date] = {
                 schedules: [],
@@ -181,123 +138,71 @@ const eventsByDate = computed(() => {
             grouped[date].residents.add(event.extendedProps.resident_id);
         }
     });
-    console.log("eventsByDate computed - grouped:", grouped);
+    console.log("Computed: eventsByDate keys:", Object.keys(grouped));
     return grouped;
 });
 
-// 日付セルのカスタムコンテンツ（日付番号のみを返す）
-const dayCellContent = (info) => {
-    // 日付番号のみを返し、コンテンツはdayCellDidMountで追加
-    return info.dayNumberText;
-};
-
-// 日付セルがマウントされた後にコンテンツを追加
-const dayCellDidMount = (info) => {
+// カレンダーのセルコンテンツを生成する関数
+const renderDayCellContent = (info) => {
     const dateStr = dayjs(info.date).format("YYYY-MM-DD");
     const dayData = eventsByDate.value[dateStr];
-
-    // FullCalendarのDOM構造:
-    // .fc-daygrid-day
-    //   .fc-daygrid-day-frame
-    //     .fc-daygrid-day-number (日付番号)
-    //     .fc-daygrid-day-events (デフォルトイベントコンテナ - 非表示にする)
-    //     .fc-daygrid-day-bg (背景)
-
-    // .fc-daygrid-day-frameを取得
-    const dayFrame = info.el.querySelector(".fc-daygrid-day-frame");
-    if (!dayFrame) return;
-
-    // 当日かどうかを判定
-    const todayStr = dayjs().format("YYYY-MM-DD");
-    const isToday = dateStr === todayStr;
-
-    // 当日のセルの透明な膜（背景要素）を削除
-    if (isToday) {
-        // .fc-daygrid-day-bg要素を非表示にする
-        const dayBg = dayFrame.querySelector(".fc-daygrid-day-bg");
-        if (dayBg) {
-            dayBg.style.display = "none";
-        }
-
-        // セル全体の背景も透明にする
-        const dayCell = info.el;
-        if (dayCell) {
-            dayCell.style.backgroundColor = "transparent";
-        }
-    }
-
-    // 日付番号要素を取得して当日のスタイルを適用
-    const dayNumberEl = dayFrame.querySelector(".fc-daygrid-day-number");
-    if (dayNumberEl) {
-        if (isToday) {
-            // ダークモードかどうかを判定
-            const isDarkMode =
-                document.documentElement.classList.contains("dark");
-
-            // 当日の場合はTailwindクラスを追加
-            dayNumberEl.classList.add(
-                "bg-blue-600",
-                "text-white",
-                "rounded",
-                "dark:bg-blue-700"
-            );
-            // 既存のスタイルを上書き（ダークモード対応）
-            dayNumberEl.style.backgroundColor = isDarkMode
-                ? "#1d4ed8"
-                : "#2563eb";
-            dayNumberEl.style.color = "white";
-            dayNumberEl.style.borderRadius = "4px";
-        } else {
-            // 当日でない場合は当日用のクラスを削除
-            dayNumberEl.classList.remove(
-                "bg-blue-600",
-                "text-white",
-                "rounded",
-                "dark:bg-blue-700"
-            );
-            // スタイルをリセット
-            dayNumberEl.style.backgroundColor = "";
-            dayNumberEl.style.color = "";
-            dayNumberEl.style.borderRadius = "";
-        }
-    }
-
-    // デフォルトのイベント表示を非表示にする
-    const dayEvents = dayFrame.querySelector(".fc-daygrid-day-events");
-    if (dayEvents) {
-        dayEvents.style.display = "none";
-    }
-
-    // 既存のカスタムコンテンツを削除
-    const existingContent = dayFrame.querySelector(".custom-day-content");
-    if (existingContent) {
-        existingContent.remove();
-    }
-
-    // カスタムコンテンツコンテナを作成
-    const contentContainer = document.createElement("div");
-    contentContainer.className =
-        "flex-1 flex flex-col p-1 gap-1 min-h-0 overflow-hidden w-full custom-day-content";
-
-    // .fc-daygrid-day-numberの後に挿入（既に取得済みのdayNumberElを使用）
-    if (dayNumberEl && dayNumberEl.nextSibling) {
-        dayFrame.insertBefore(contentContainer, dayNumberEl.nextSibling);
+    
+    // 特定の日付（例：イベントがあるはずの日）でログを出力
+    if (dayData) {
+        console.log(`Render: Found data for ${dateStr}:`, dayData.schedules.length, "schedules");
     } else {
-        dayFrame.appendChild(contentContainer);
+        // データがない場合も、特定の日付（例：4日）だけログ出す
+        if (dateStr.endsWith("-04") || dateStr.endsWith("-02")) {
+             console.log(`Render: No data for ${dateStr}`);
+        }
     }
+    
+    const isToday = dateStr === dayjs().format("YYYY-MM-DD");
+    const isDarkMode = document.documentElement.classList.contains("dark");
 
-    // スケジュールセクション（上半分）- 常に作成
+    // コンテナ
+    const container = document.createElement("div");
+    container.className = "flex flex-col h-full w-full overflow-hidden";
+    
+    // 1. 日付番号エリア
+    const headerDiv = document.createElement("div");
+    headerDiv.className = "flex justify-end p-1";
+    
+    const dayNumberLink = document.createElement("a");
+    dayNumberLink.className = "fc-daygrid-day-number cursor-pointer no-underline hover:underline";
+    dayNumberLink.innerText = info.dayNumberText;
+    
+    // 当日のスタイル適用
+    if (isToday) {
+        dayNumberLink.classList.add(
+            "bg-blue-600",
+            "text-white",
+            "rounded",
+            "px-1",
+            "dark:bg-blue-700"
+        );
+        dayNumberLink.style.backgroundColor = isDarkMode ? "#1d4ed8" : "#2563eb";
+        dayNumberLink.style.color = "white";
+    } else {
+        dayNumberLink.classList.add("text-gray-700", "dark:text-gray-300");
+    }
+    
+    headerDiv.appendChild(dayNumberLink);
+    container.appendChild(headerDiv);
+
+    // 2. カスタムコンテンツエリア
+    const contentContainer = document.createElement("div");
+    contentContainer.className = "flex-1 flex flex-col p-1 gap-1 min-h-0 overflow-hidden w-full custom-day-content";
+
+    // スケジュールセクション（上半分）
     const schedulesSection = document.createElement("div");
-    schedulesSection.className =
-        "flex flex-col gap-0.5 overflow-y-auto min-h-[60px] flex-1 border-b-4 border-gray-400 pb-2 mb-2 bg-gray-50";
+    schedulesSection.className = "flex flex-col gap-0.5 overflow-y-auto min-h-[60px] flex-1 border-b-4 border-gray-400 pb-2 mb-2 bg-gray-50 dark:bg-gray-700";
 
     if (dayData && dayData.schedules.length > 0) {
         dayData.schedules.forEach((schedule) => {
             const scheduleItem = document.createElement("div");
-            scheduleItem.className =
-                "flex items-center gap-1 px-1 py-0.5 rounded text-sm text-white cursor-pointer hover:opacity-80";
-            scheduleItem.style.backgroundColor =
-                schedule.backgroundColor || "#3B82F6";
+            scheduleItem.className = "flex items-center gap-1 px-1 py-0.5 rounded text-sm text-white cursor-pointer hover:opacity-80";
+            scheduleItem.style.backgroundColor = schedule.backgroundColor || "#3B82F6";
             scheduleItem.setAttribute("data-event-id", schedule.id);
 
             const timeSpan = document.createElement("span");
@@ -305,15 +210,13 @@ const dayCellDidMount = (info) => {
             timeSpan.textContent = dayjs(schedule.start).format("HH:mm");
 
             const titleSpan = document.createElement("span");
-            titleSpan.className =
-                "flex-1 overflow-hidden text-ellipsis whitespace-nowrap";
-            titleSpan.textContent =
-                schedule.extendedProps?.schedule_type_name || schedule.title;
+            titleSpan.className = "flex-1 overflow-hidden text-ellipsis whitespace-nowrap";
+            titleSpan.textContent = schedule.extendedProps?.schedule_type_name || schedule.title;
 
             scheduleItem.appendChild(timeSpan);
             scheduleItem.appendChild(titleSpan);
 
-            // クリックイベントをバインド
+            // クリックイベント
             scheduleItem.addEventListener("click", (e) => {
                 e.stopPropagation();
                 const fcEvent = {
@@ -331,25 +234,23 @@ const dayCellDidMount = (info) => {
             schedulesSection.appendChild(scheduleItem);
         });
     }
+    contentContainer.appendChild(schedulesSection);
 
-    // 入浴予定者セクション（下半分）- 常に作成
+    // 入浴予定者セクション（下半分）
     const residentsSection = document.createElement("div");
-    residentsSection.className =
-        "flex flex-col min-h-[50px] flex-1 border-t-4 border-gray-400 pt-2 bg-gray-100";
+    residentsSection.className = "flex flex-col min-h-[50px] flex-1 border-t-4 border-gray-400 pt-2 bg-gray-100 dark:bg-gray-600";
 
     const labelDiv = document.createElement("div");
-    labelDiv.className = "text-xs font-bold text-gray-600 mb-0.5";
+    labelDiv.className = "text-xs font-bold text-gray-600 dark:text-gray-300 mb-0.5";
     labelDiv.textContent = "入浴予定者";
+    residentsSection.appendChild(labelDiv);
 
     const listDiv = document.createElement("div");
-
     if (dayData && dayData.residents.size > 0) {
-        listDiv.className = "text-sm text-gray-700 leading-relaxed break-words";
+        listDiv.className = "text-sm text-gray-700 dark:text-gray-200 leading-relaxed break-words";
         const residentsList = Array.from(dayData.residents)
             .map((residentId) => {
-                const resident = residents.value.find(
-                    (r) => r.id === residentId
-                );
+                const resident = residents.value.find((r) => r.id === residentId);
                 return resident ? resident.name : "";
             })
             .filter(Boolean);
@@ -358,13 +259,31 @@ const dayCellDidMount = (info) => {
         listDiv.className = "text-sm text-gray-400 italic";
         listDiv.textContent = "なし";
     }
-
-    residentsSection.appendChild(labelDiv);
     residentsSection.appendChild(listDiv);
-
-    // 両方のセクションを常に追加
-    contentContainer.appendChild(schedulesSection);
     contentContainer.appendChild(residentsSection);
+
+    container.appendChild(contentContainer);
+
+    return { domNodes: [container] };
+};
+
+// 日付セルがマウントされた後の処理（背景のクリアなど）
+const dayCellDidMount = (info) => {
+    // デフォルトのイベントコンテナなどを非表示にする必要があればここで
+    const dayFrame = info.el.querySelector(".fc-daygrid-day-frame");
+    if (dayFrame) {
+        // デフォルトのイベント表示を非表示
+        const dayEvents = dayFrame.querySelector(".fc-daygrid-day-events");
+        if (dayEvents) {
+            dayEvents.style.display = "none";
+        }
+        
+        // 背景を透明に（必要な場合）
+        const dayBg = dayFrame.querySelector(".fc-daygrid-day-bg");
+        if (dayBg) {
+            dayBg.style.display = "none";
+        }
+    }
 };
 
 // FullCalendarの設定
@@ -383,15 +302,15 @@ const calendarOptions = computed(() => ({
         week: "週",
         day: "日",
     },
-    events: events.value,
+    // events: events.value, // ここでの指定を削除し、プロップとして渡す
     eventDisplay: "none", // カスタム表示のため標準イベント表示を無効化
     height: "auto",
     editable: false,
     selectable: false,
     dateClick: handleDateClick,
     eventClick: handleEventClick,
-    dayCellContent: dayCellContent, // カスタム日付セルコンテンツ
-    dayCellDidMount: dayCellDidMount, // 日付セルマウント後の処理
+    dayCellContent: renderDayCellContent, // カスタム日付セルコンテンツ（全置換）
+    dayCellDidMount: dayCellDidMount, // 日付セルマウント後の処理（スタイル調整のみ）
     dayMaxEvents: false, // カスタム表示のため無効化
 }));
 
@@ -417,106 +336,13 @@ const handleScheduleCreated = (newEvent) => {
             calendarApi.addEvent(newEvent);
         }
 
-        // eventsByDateが更新されるのを待つ（複数のnextTickで確実に更新されるのを待つ）
+        // eventsByDateが更新されるのを待つ
         nextTick(() => {
-            // もう一度nextTickで確実にeventsByDateが更新されるのを待つ
-            nextTick(() => {
-                console.log("eventsByDate updated after creation");
-
-                // FullCalendarのイベントを再読み込み
-                if (calendarRef.value) {
-                    const calendarApi = calendarRef.value.getApi();
-
-                    // 作成されたスケジュールの日付のセルを手動で更新
-                    if (createdDate) {
-                        const dayElements =
-                            calendarApi.el.querySelectorAll(".fc-daygrid-day");
-                        dayElements.forEach((dayEl) => {
-                            const dayNumberEl = dayEl.querySelector(
-                                ".fc-daygrid-day-number"
-                            );
-                            if (dayNumberEl) {
-                                // 日付番号から日付を推測
-                                const view = calendarApi.view;
-                                if (view && view.activeStart) {
-                                    const cellIndex =
-                                        Array.from(dayElements).indexOf(dayEl);
-                                    if (cellIndex >= 0) {
-                                        const cellDate = dayjs(
-                                            view.activeStart
-                                        ).add(cellIndex, "day");
-                                        const cellDateStr =
-                                            cellDate.format("YYYY-MM-DD");
-
-                                        // 作成されたスケジュールの日付のセルのみ更新
-                                        if (cellDateStr === createdDate) {
-                                            const dayFrame =
-                                                dayEl.querySelector(
-                                                    ".fc-daygrid-day-frame"
-                                                );
-                                            if (dayFrame) {
-                                                // 既存のカスタムコンテンツを完全に削除
-                                                const existingContents =
-                                                    dayFrame.querySelectorAll(
-                                                        ".custom-day-content"
-                                                    );
-                                                existingContents.forEach(
-                                                    (content) => {
-                                                        content.remove();
-                                                    }
-                                                );
-
-                                                // 念のため、dayFrame内のすべての子要素を確認して、カスタムコンテンツを削除
-                                                const dayNumberEl =
-                                                    dayFrame.querySelector(
-                                                        ".fc-daygrid-day-number"
-                                                    );
-                                                if (dayNumberEl) {
-                                                    // dayNumberElの次の兄弟要素から最後まで、カスタムコンテンツの可能性がある要素を削除
-                                                    let nextSibling =
-                                                        dayNumberEl.nextSibling;
-                                                    while (nextSibling) {
-                                                        const toRemove =
-                                                            nextSibling;
-                                                        nextSibling =
-                                                            nextSibling.nextSibling;
-                                                        // .fc-daygrid-day-eventsと.fc-daygrid-day-bgは残す
-                                                        if (
-                                                            !toRemove.classList.contains(
-                                                                "fc-daygrid-day-events"
-                                                            ) &&
-                                                            !toRemove.classList.contains(
-                                                                "fc-daygrid-day-bg"
-                                                            )
-                                                        ) {
-                                                            toRemove.remove();
-                                                        }
-                                                    }
-                                                }
-
-                                                // dayCellDidMountを再実行
-                                                const cellInfo = {
-                                                    date: cellDate.toDate(),
-                                                    el: dayEl,
-                                                };
-                                                dayCellDidMount(cellInfo);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        });
-                    } else {
-                        // 日付が取得できない場合は、すべてのセルを再レンダリング
-                        calendarApi.render();
-                    }
-
-                    console.log(
-                        "Calendar updated after creation, events:",
-                        calendarApi.getEvents().length
-                    );
-                }
-            });
+            // FullCalendarのイベントを再読み込み
+            if (calendarRef.value) {
+                const calendarApi = calendarRef.value.getApi();
+                calendarApi.render();
+            }
         });
 
         // 月間統計情報も更新
@@ -581,121 +407,13 @@ const handleScheduleDeleted = (deletedScheduleId) => {
             }
         }
 
-        // eventsByDateが更新されるのを待つ（複数のnextTickで確実に更新されるのを待つ）
+        // eventsByDateが更新されるのを待つ
         nextTick(() => {
-            // もう一度nextTickで確実にeventsByDateが更新されるのを待つ
-            nextTick(() => {
-                console.log("eventsByDate updated after deletion");
-
-                // FullCalendarのイベントを再読み込み
-                if (calendarRef.value) {
-                    const calendarApi = calendarRef.value.getApi();
-
-                    // すべてのイベントを削除してから再追加
-                    calendarApi.removeAllEvents();
-
-                    // 新しいイベントを追加
-                    if (
-                        Array.isArray(events.value) &&
-                        events.value.length > 0
-                    ) {
-                        events.value.forEach((event) => {
-                            calendarApi.addEvent(event);
-                        });
-                    }
-
-                    // 削除されたスケジュールの日付のセルを手動で更新
-                    if (deletedDate) {
-                        const dayElements =
-                            calendarApi.el.querySelectorAll(".fc-daygrid-day");
-                        dayElements.forEach((dayEl) => {
-                            const dayNumberEl = dayEl.querySelector(
-                                ".fc-daygrid-day-number"
-                            );
-                            if (dayNumberEl) {
-                                // 日付番号から日付を推測
-                                const view = calendarApi.view;
-                                if (view && view.activeStart) {
-                                    const cellIndex =
-                                        Array.from(dayElements).indexOf(dayEl);
-                                    if (cellIndex >= 0) {
-                                        const cellDate = dayjs(
-                                            view.activeStart
-                                        ).add(cellIndex, "day");
-                                        const cellDateStr =
-                                            cellDate.format("YYYY-MM-DD");
-
-                                        // 削除されたスケジュールの日付のセルのみ更新
-                                        if (cellDateStr === deletedDate) {
-                                            const dayFrame =
-                                                dayEl.querySelector(
-                                                    ".fc-daygrid-day-frame"
-                                                );
-                                            if (dayFrame) {
-                                                // 既存のカスタムコンテンツを完全に削除
-                                                // .custom-day-contentクラスを持つ要素をすべて削除
-                                                const existingContents =
-                                                    dayFrame.querySelectorAll(
-                                                        ".custom-day-content"
-                                                    );
-                                                existingContents.forEach(
-                                                    (content) => {
-                                                        content.remove();
-                                                    }
-                                                );
-
-                                                // 念のため、dayFrame内のすべての子要素を確認して、カスタムコンテンツを削除
-                                                // .fc-daygrid-day-number以外の要素を削除（カスタムコンテンツの可能性がある）
-                                                const dayNumberEl =
-                                                    dayFrame.querySelector(
-                                                        ".fc-daygrid-day-number"
-                                                    );
-                                                if (dayNumberEl) {
-                                                    // dayNumberElの次の兄弟要素から最後まで、カスタムコンテンツの可能性がある要素を削除
-                                                    let nextSibling =
-                                                        dayNumberEl.nextSibling;
-                                                    while (nextSibling) {
-                                                        const toRemove =
-                                                            nextSibling;
-                                                        nextSibling =
-                                                            nextSibling.nextSibling;
-                                                        // .fc-daygrid-day-eventsと.fc-daygrid-day-bgは残す
-                                                        if (
-                                                            !toRemove.classList.contains(
-                                                                "fc-daygrid-day-events"
-                                                            ) &&
-                                                            !toRemove.classList.contains(
-                                                                "fc-daygrid-day-bg"
-                                                            )
-                                                        ) {
-                                                            toRemove.remove();
-                                                        }
-                                                    }
-                                                }
-
-                                                // dayCellDidMountを再実行
-                                                const cellInfo = {
-                                                    date: cellDate.toDate(),
-                                                    el: dayEl,
-                                                };
-                                                dayCellDidMount(cellInfo);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        });
-                    } else {
-                        // 日付が取得できない場合は、すべてのセルを再レンダリング
-                        calendarApi.render();
-                    }
-
-                    console.log(
-                        "Calendar updated after deletion, events:",
-                        calendarApi.getEvents().length
-                    );
-                }
-            });
+            // FullCalendarのイベントを再読み込み
+            if (calendarRef.value) {
+                const calendarApi = calendarRef.value.getApi();
+                calendarApi.render();
+            }
         });
 
         // 月間統計情報も更新
@@ -727,9 +445,32 @@ const closeScheduleModal = () => {
                     <div class="p-6 text-gray-900 dark:text-gray-100">
                         <h1 class="text-2xl font-bold mb-6">カレンダー</h1>
 
+                        <!-- デバッグ用セクション -->
+                        <div class="mb-4 p-4 bg-yellow-100 border border-yellow-400 rounded text-sm text-black">
+                            <h3 class="font-bold mb-2">デバッグ情報</h3>
+                            <div class="grid grid-cols-2 gap-2">
+                                <div>Events Length: {{ events.length }}</div>
+                                <div>Grouped Dates: {{ Object.keys(eventsByDate).length }}</div>
+                                <div>Calendar Ref: {{ calendarRef ? 'Present' : 'Null' }}</div>
+                                <div>Current Date: {{ currentDate }}</div>
+                            </div>
+                            <div class="mt-2 flex gap-2">
+                                <button 
+                                    @click="() => calendarRef.getApi().render()"
+                                    class="px-3 py-1 bg-green-500 text-white rounded hover:bg-green-600"
+                                >
+                                    強制レンダリング (Render)
+                                </button>
+                            </div>
+                            <div class="mt-2 text-xs text-gray-600">
+                                <p>Events Sample: {{ events.length > 0 ? JSON.stringify(events[0]).substring(0, 100) + '...' : 'None' }}</p>
+                            </div>
+                        </div>
+
                         <!-- カレンダー表示 -->
                         <div class="calendar-container">
                             <FullCalendar
+                                :key="calendarKey"
                                 ref="calendarRef"
                                 :options="calendarOptions"
                                 @datesSet="handleMonthChange"
@@ -794,7 +535,7 @@ const closeScheduleModal = () => {
     </AuthenticatedLayout>
 </template>
 
-<style>
+<style scoped>
 .calendar-container {
     margin-top: 1rem;
 }

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -398,10 +398,23 @@ const closeScheduleModal = () => {
     overflow-y: auto;
     min-height: 60px !important;
     max-height: none;
-    border-bottom: 3px solid #d1d5db !important;
-    padding-bottom: 6px;
-    margin-bottom: 6px;
-    box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.1);
+    border-bottom: 4px solid #9ca3af !important;
+    padding-bottom: 8px;
+    margin-bottom: 8px;
+    background-color: rgba(249, 250, 251, 0.5);
+    position: relative;
+}
+
+/* 分割線をより明確にするための疑似要素 */
+:deep(.schedules-section::after) {
+    content: '';
+    position: absolute;
+    bottom: -4px;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background-color: #6b7280;
+    border-top: 1px solid #4b5563;
 }
 
 :deep(.calendar-schedule-item) {
@@ -439,9 +452,23 @@ const closeScheduleModal = () => {
     flex-direction: column !important;
     min-height: 50px !important;
     max-height: none;
-    padding-top: 6px;
-    border-top: 1px solid rgba(0, 0, 0, 0.05);
-    margin-top: 2px;
+    padding-top: 8px;
+    border-top: 4px solid #9ca3af !important;
+    margin-top: 0;
+    background-color: rgba(243, 244, 246, 0.5);
+    position: relative;
+}
+
+/* 分割線をより明確にするための疑似要素 */
+:deep(.calendar-residents-section::before) {
+    content: '';
+    position: absolute;
+    top: -4px;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background-color: #6b7280;
+    border-bottom: 1px solid #4b5563;
 }
 
 :deep(.residents-label) {

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -68,8 +68,21 @@ const handleEventClick = (info) => {
 const eventsByDate = computed(() => {
     const grouped = {}
     console.log('eventsByDate computed - events.value:', events.value)
-    events.value.forEach(event => {
+    console.log('eventsByDate computed - events.value.length:', events.value?.length)
+    
+    if (!events.value || events.value.length === 0) {
+        console.warn('events.value is empty or undefined')
+        return grouped
+    }
+    
+    events.value.forEach((event, index) => {
+        console.log(`Processing event ${index}:`, event)
+        if (!event.start) {
+            console.warn(`Event ${index} has no start date:`, event)
+            return
+        }
         const date = dayjs(event.start).format('YYYY-MM-DD')
+        console.log(`Event ${index} date:`, date)
         if (!grouped[date]) {
             grouped[date] = {
                 schedules: [],

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -147,55 +147,55 @@ const renderDayCellContent = (info) => {
 
     // コンテナ
     const container = document.createElement("div");
-    container.className = "flex flex-col h-full w-full overflow-hidden";
+    container.className = "flex flex-col h-full w-full overflow-hidden relative group transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-800/50";
     
     // 1. 日付番号エリア
     const headerDiv = document.createElement("div");
-    headerDiv.className = "flex justify-end p-1";
+    headerDiv.className = "flex justify-between items-start p-1.5";
     
-    const dayNumberLink = document.createElement("a");
-    dayNumberLink.className = "fc-daygrid-day-number cursor-pointer no-underline hover:underline";
-    dayNumberLink.innerText = info.dayNumberText;
+    // 日付番号
+    const dayNumberSpan = document.createElement("span");
+    dayNumberSpan.className = "text-sm font-medium w-7 h-7 flex items-center justify-center rounded-full transition-colors";
+    dayNumberSpan.innerText = info.dayNumberText.replace('日', ''); // "日"を削除して数字のみに
     
     // 当日のスタイル適用
     if (isToday) {
-        dayNumberLink.classList.add(
+        dayNumberSpan.classList.add(
             "bg-blue-600",
             "text-white",
-            "rounded",
-            "px-1",
-            "dark:bg-blue-700"
+            "shadow-md",
+            "dark:bg-blue-500"
         );
-        dayNumberLink.style.backgroundColor = isDarkMode ? "#1d4ed8" : "#2563eb";
-        dayNumberLink.style.color = "white";
     } else {
-        dayNumberLink.classList.add("text-gray-700", "dark:text-gray-300");
+        dayNumberSpan.classList.add("text-gray-700", "dark:text-gray-300");
     }
     
-    headerDiv.appendChild(dayNumberLink);
+    headerDiv.appendChild(dayNumberSpan);
     container.appendChild(headerDiv);
 
     // 2. カスタムコンテンツエリア
     const contentContainer = document.createElement("div");
-    contentContainer.className = "flex-1 flex flex-col p-1 gap-1 min-h-0 overflow-hidden w-full custom-day-content";
+    contentContainer.className = "flex-1 flex flex-col px-1 pb-1 gap-1 min-h-0 overflow-hidden w-full";
 
-    // スケジュールセクション（上半分）
+    // スケジュールリスト
     const schedulesSection = document.createElement("div");
-    schedulesSection.className = "flex flex-col gap-0.5 overflow-y-auto min-h-[60px] flex-1 border-b-4 border-gray-400 pb-2 mb-2 bg-gray-50 dark:bg-gray-700";
+    schedulesSection.className = "flex flex-col gap-1 overflow-y-auto flex-1 min-h-0";
 
     if (dayData && dayData.schedules.length > 0) {
         dayData.schedules.forEach((schedule) => {
             const scheduleItem = document.createElement("div");
-            scheduleItem.className = "flex items-center gap-1 px-1 py-0.5 rounded text-sm text-white cursor-pointer hover:opacity-80";
+            // モダンなピル型デザイン
+            scheduleItem.className = "flex items-center gap-1.5 px-2 py-1 rounded-md text-xs text-white cursor-pointer hover:opacity-90 transition-all shadow-sm transform hover:scale-[1.02]";
             scheduleItem.style.backgroundColor = schedule.backgroundColor || "#3B82F6";
+            scheduleItem.style.borderLeft = `3px solid ${schedule.borderColor || 'rgba(0,0,0,0.1)'}`;
             scheduleItem.setAttribute("data-event-id", schedule.id);
 
             const timeSpan = document.createElement("span");
-            timeSpan.className = "font-bold whitespace-nowrap";
+            timeSpan.className = "font-bold whitespace-nowrap opacity-90 text-[10px]";
             timeSpan.textContent = dayjs(schedule.start).format("HH:mm");
 
             const titleSpan = document.createElement("span");
-            titleSpan.className = "flex-1 overflow-hidden text-ellipsis whitespace-nowrap";
+            titleSpan.className = "flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-medium";
             titleSpan.textContent = schedule.extendedProps?.schedule_type_name || schedule.title;
 
             scheduleItem.appendChild(timeSpan);
@@ -221,31 +221,33 @@ const renderDayCellContent = (info) => {
     }
     contentContainer.appendChild(schedulesSection);
 
-    // 入浴予定者セクション（下半分）
-    const residentsSection = document.createElement("div");
-    residentsSection.className = "flex flex-col min-h-[50px] flex-1 border-t-4 border-gray-400 pt-2 bg-gray-100 dark:bg-gray-600";
-
-    const labelDiv = document.createElement("div");
-    labelDiv.className = "text-xs font-bold text-gray-600 dark:text-gray-300 mb-0.5";
-    labelDiv.textContent = "入浴予定者";
-    residentsSection.appendChild(labelDiv);
-
-    const listDiv = document.createElement("div");
+    // 入浴予定者セクション（下部に控えめに表示）
     if (dayData && dayData.residents.size > 0) {
-        listDiv.className = "text-sm text-gray-700 dark:text-gray-200 leading-relaxed break-words";
+        const residentsSection = document.createElement("div");
+        residentsSection.className = "mt-auto pt-1 border-t border-gray-100 dark:border-gray-700";
+
+        const residentsContainer = document.createElement("div");
+        residentsContainer.className = "flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400";
+        
+        // アイコン
+        const icon = document.createElement("i");
+        icon.className = "bi bi-droplet-fill text-blue-400 text-[10px]";
+        residentsContainer.appendChild(icon);
+
+        const listSpan = document.createElement("span");
+        listSpan.className = "truncate";
         const residentsList = Array.from(dayData.residents)
             .map((residentId) => {
                 const resident = residents.value.find((r) => r.id === residentId);
                 return resident ? resident.name : "";
             })
             .filter(Boolean);
-        listDiv.textContent = residentsList.join(", ");
-    } else {
-        listDiv.className = "text-sm text-gray-400 italic";
-        listDiv.textContent = "なし";
+        listSpan.textContent = residentsList.join(", ");
+        
+        residentsContainer.appendChild(listSpan);
+        residentsSection.appendChild(residentsContainer);
+        contentContainer.appendChild(residentsSection);
     }
-    residentsSection.appendChild(listDiv);
-    contentContainer.appendChild(residentsSection);
 
     container.appendChild(contentContainer);
 
@@ -297,6 +299,7 @@ const calendarOptions = computed(() => ({
     dayCellContent: renderDayCellContent, // カスタム日付セルコンテンツ（全置換）
     dayCellDidMount: dayCellDidMount, // 日付セルマウント後の処理（スタイル調整のみ）
     dayMaxEvents: false, // カスタム表示のため無効化
+    dayHeaderFormat: { weekday: 'short' }, // 曜日を短縮形に（月、火...）
 }));
 
 // スケジュール作成成功時の処理
@@ -415,36 +418,20 @@ const closeScheduleModal = () => {
     <AuthenticatedLayout>
         <Head title="カレンダー" />
 
-        <div class="py-12">
-            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                <div
-                    class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg"
-                >
-                    <div class="p-6 text-gray-900 dark:text-gray-100">
-                        <h1 class="text-2xl font-bold mb-6">カレンダー</h1>
+        <div class="py-8 bg-gray-50 dark:bg-gray-900 min-h-screen">
+            <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-8">
+                
+                <!-- ヘッダーエリア -->
+                <div class="flex flex-col md:flex-row justify-between items-center mb-8 gap-4">
+                    <div>
+                        <h1 class="text-3xl font-bold text-gray-800 dark:text-gray-100 tracking-tight">カレンダー</h1>
+                        <p class="text-gray-500 dark:text-gray-400 mt-1">スケジュールの確認と管理ができます</p>
+                    </div>
+                </div>
 
-                        <!-- デバッグ用セクション -->
-                        <!-- <div class="mb-4 p-4 bg-yellow-100 border border-yellow-400 rounded text-sm text-black">
-                            <h3 class="font-bold mb-2">デバッグ情報</h3>
-                            <div class="grid grid-cols-2 gap-2">
-                                <div>Events Length: {{ events.length }}</div>
-                                <div>Grouped Dates: {{ Object.keys(eventsByDate).length }}</div>
-                                <div>Calendar Ref: {{ calendarRef ? 'Present' : 'Null' }}</div>
-                                <div>Current Date: {{ currentDate }}</div>
-                            </div>
-                            <div class="mt-2 flex gap-2">
-                                <button 
-                                    @click="() => calendarRef.getApi().render()"
-                                    class="px-3 py-1 bg-green-500 text-white rounded hover:bg-green-600"
-                                >
-                                    強制レンダリング (Render)
-                                </button>
-                            </div>
-                            <div class="mt-2 text-xs text-gray-600">
-                                <p>Events Sample: {{ events.length > 0 ? JSON.stringify(events[0]).substring(0, 100) + '...' : 'None' }}</p>
-                            </div>
-                        </div> -->
-
+                <!-- カレンダーメインエリア -->
+                <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
+                    <div class="p-6">
                         <!-- カレンダー表示 -->
                         <div class="calendar-container">
                             <FullCalendar
@@ -454,34 +441,43 @@ const closeScheduleModal = () => {
                                 @datesSet="handleMonthChange"
                             />
                         </div>
+                    </div>
+                </div>
 
-                        <!-- 月間統計情報 -->
-                        <div class="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
-                            <div
-                                class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg"
-                            >
-                                <div
-                                    class="text-sm text-gray-600 dark:text-gray-400"
-                                >
-                                    総スケジュール数
-                                </div>
-                                <div class="text-2xl font-bold">
-                                    {{ monthStats.total }}
+                <!-- 月間統計情報（カードデザイン） -->
+                <div class="mt-8">
+                    <h2 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-4 px-1">今月の統計</h2>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                        <!-- 総スケジュール数 -->
+                        <div class="bg-white dark:bg-gray-800 p-5 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 transition-transform hover:-translate-y-1 duration-300">
+                            <div class="flex items-center justify-between mb-2">
+                                <div class="text-sm font-medium text-gray-500 dark:text-gray-400">総スケジュール</div>
+                                <div class="p-2 bg-blue-50 dark:bg-blue-900/30 rounded-lg text-blue-600 dark:text-blue-400">
+                                    <i class="bi bi-calendar-check text-lg"></i>
                                 </div>
                             </div>
-                            <div
-                                v-for="type in scheduleTypes"
-                                :key="type.id"
-                                class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg"
-                            >
-                                <div
-                                    class="text-sm text-gray-600 dark:text-gray-400"
+                            <div class="text-3xl font-bold text-gray-800 dark:text-gray-100">
+                                {{ monthStats.total }}
+                            </div>
+                        </div>
+
+                        <!-- スケジュールタイプ別 -->
+                        <div
+                            v-for="type in scheduleTypes"
+                            :key="type.id"
+                            class="bg-white dark:bg-gray-800 p-5 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 transition-transform hover:-translate-y-1 duration-300"
+                        >
+                            <div class="flex items-center justify-between mb-2">
+                                <div class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ type.name }}</div>
+                                <div 
+                                    class="p-2 rounded-lg"
+                                    :style="{ backgroundColor: type.color ? `${type.color}20` : '#e5e7eb', color: type.color || '#6b7280' }"
                                 >
-                                    {{ type.name }}
+                                    <i class="bi bi-circle-fill text-xs"></i>
                                 </div>
-                                <div class="text-2xl font-bold">
-                                    {{ monthStats.by_type[type.id] || 0 }}
-                                </div>
+                            </div>
+                            <div class="text-3xl font-bold text-gray-800 dark:text-gray-100">
+                                {{ monthStats.by_type[type.id] || 0 }}
                             </div>
                         </div>
                     </div>
@@ -514,196 +510,129 @@ const closeScheduleModal = () => {
 </template>
 
 <style scoped>
+/* カレンダーコンテナ */
 .calendar-container {
-    margin-top: 1rem;
+    font-family: 'Inter', sans-serif;
 }
 
-/* カレンダー全体を大きくする */
+/* FullCalendarの全体スタイル調整 */
 :deep(.fc) {
-    font-size: 1.1rem;
+    --fc-border-color: #f3f4f6; /* 枠線を薄く */
+    --fc-today-bg-color: transparent; /* 今日の背景色をクリア */
+    --fc-neutral-bg-color: #f9fafb;
+    --fc-page-bg-color: #ffffff;
 }
 
-/* FullCalendarの日付セルを上下2分割にする */
-/* .fc-daygrid-day-frameはFullCalendarが自動生成するフレーム要素 */
-:deep(.fc-daygrid-day-frame) {
-    display: flex !important;
-    flex-direction: column !important;
-    height: 100% !important;
-    min-height: 150px !important;
-    position: relative;
+.dark :deep(.fc) {
+    --fc-border-color: #374151;
+    --fc-neutral-bg-color: #1f2937;
+    --fc-page-bg-color: #1f2937;
 }
 
-:deep(.fc-daygrid-day) {
-    height: auto;
-    min-height: 150px;
+/* ヘッダーツールバー */
+:deep(.fc-header-toolbar) {
+    margin-bottom: 1.5rem !important;
 }
 
-/* 日付番号部分 - 上部に固定 */
-:deep(.fc-daygrid-day-number) {
-    font-weight: bold;
-    font-size: 1.1rem;
-    padding: 4px 8px;
-    border-bottom: 1px solid #e5e7eb;
-    background-color: #f9fafb;
-    flex-shrink: 0 !important;
-    order: 1;
+:deep(.fc-toolbar-title) {
+    font-size: 1.5rem !important;
+    font-weight: 700;
+    color: #1f2937;
 }
 
-/* デフォルトのイベント表示を非表示 */
-:deep(.fc-daygrid-day-events) {
-    display: none !important;
+.dark :deep(.fc-toolbar-title) {
+    color: #f3f4f6;
 }
 
-/* カスタムコンテンツコンテナ - 日付番号の下に配置 */
-:deep(.custom-day-content) {
-    flex: 1 !important;
-    display: flex !important;
-    flex-direction: column !important;
-    padding: 4px;
-    gap: 4px;
-    min-height: 0;
-    overflow: hidden;
-    order: 2;
-    width: 100%;
-}
-
-/* スケジュールセクション（上半分） */
-:deep(.schedules-section) {
-    flex: 1 1 50% !important;
-    display: flex !important;
-    flex-direction: column !important;
-    gap: 2px;
-    overflow-y: auto;
-    min-height: 60px !important;
-    max-height: none;
-    border-bottom: 4px solid #9ca3af !important;
-    padding-bottom: 8px;
-    margin-bottom: 8px;
-    background-color: rgba(249, 250, 251, 0.5);
-    position: relative;
-}
-
-/* 分割線をより明確にするための疑似要素 */
-:deep(.schedules-section::after) {
-    content: "";
-    position: absolute;
-    bottom: -4px;
-    left: 0;
-    right: 0;
-    height: 4px;
-    background-color: #6b7280;
-    border-top: 1px solid #4b5563;
-}
-
-:deep(.calendar-schedule-item) {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    padding: 2px 4px;
-    border-radius: 3px;
-    font-size: 0.85rem;
-    color: white;
-    cursor: pointer;
-    transition: opacity 0.2s;
-}
-
-:deep(.calendar-schedule-item:hover) {
-    opacity: 0.8;
-}
-
-:deep(.schedule-time) {
-    font-weight: bold;
-    white-space: nowrap;
-}
-
-:deep(.schedule-title) {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-/* 入浴予定者セクション（下半分） */
-:deep(.calendar-residents-section) {
-    flex: 1 1 50% !important;
-    display: flex !important;
-    flex-direction: column !important;
-    min-height: 50px !important;
-    max-height: none;
-    padding-top: 8px;
-    border-top: 4px solid #9ca3af !important;
-    margin-top: 0;
-    background-color: rgba(243, 244, 246, 0.5);
-    position: relative;
-}
-
-/* 分割線をより明確にするための疑似要素 */
-:deep(.calendar-residents-section::before) {
-    content: "";
-    position: absolute;
-    top: -4px;
-    left: 0;
-    right: 0;
-    height: 4px;
-    background-color: #6b7280;
-    border-bottom: 1px solid #4b5563;
-}
-
-:deep(.residents-label) {
-    font-size: 0.75rem;
-    font-weight: bold;
-    color: #6b7280;
-    margin-bottom: 2px;
-}
-
-:deep(.residents-list) {
-    font-size: 0.85rem;
+/* ボタンのカスタマイズ */
+:deep(.fc-button) {
+    background-color: white;
+    border: 1px solid #e5e7eb;
     color: #374151;
-    line-height: 1.4;
-    word-break: break-word;
+    font-weight: 500;
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    transition: all 0.2s;
 }
 
-/* 今日の日付を強調 */
-/* 当日のセルの透明な膜（背景）を削除 */
+:deep(.fc-button:hover) {
+    background-color: #f9fafb;
+    border-color: #d1d5db;
+    color: #111827;
+}
+
+:deep(.fc-button-primary:not(:disabled).fc-button-active),
+:deep(.fc-button-primary:not(:disabled):active) {
+    background-color: #3b82f6;
+    border-color: #3b82f6;
+    color: white;
+}
+
+.dark :deep(.fc-button) {
+    background-color: #374151;
+    border-color: #4b5563;
+    color: #e5e7eb;
+}
+
+.dark :deep(.fc-button:hover) {
+    background-color: #4b5563;
+}
+
+/* 曜日ヘッダー */
+:deep(.fc-col-header-cell) {
+    padding: 0.75rem 0;
+    background-color: #f9fafb;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+:deep(.fc-col-header-cell-cushion) {
+    color: #6b7280;
+    font-weight: 600;
+    text-decoration: none;
+    font-size: 0.875rem;
+}
+
+.dark :deep(.fc-col-header-cell) {
+    background-color: #1f2937;
+    border-bottom-color: #374151;
+}
+
+.dark :deep(.fc-col-header-cell-cushion) {
+    color: #9ca3af;
+}
+
+/* 日付セルフレーム */
+:deep(.fc-daygrid-day-frame) {
+    min-height: 120px !important;
+    transition: background-color 0.2s;
+}
+
+/* 今日のセル */
 :deep(.fc-day-today) {
     background-color: transparent !important;
 }
 
-:deep(.fc-day-today .fc-daygrid-day-bg) {
-    display: none !important;
+/* スクロールバーのカスタマイズ */
+:deep(::-webkit-scrollbar) {
+    width: 4px;
+    height: 4px;
 }
 
-:deep(.fc-day-today .fc-daygrid-day-number) {
-    background-color: #3b82f6;
-    color: white;
-    border-radius: 4px;
+:deep(::-webkit-scrollbar-track) {
+    background: transparent;
 }
 
-/* ダークモード対応 */
-.dark :deep(.fc-daygrid-day-number) {
-    background-color: #374151;
-    color: #f9fafb;
-    border-bottom-color: #4b5563;
+:deep(::-webkit-scrollbar-thumb) {
+    background: #d1d5db;
+    border-radius: 2px;
 }
 
-.dark :deep(.day-content) {
-    background-color: #1f2937;
+:deep(::-webkit-scrollbar-thumb:hover) {
+    background: #9ca3af;
 }
 
-.dark :deep(.calendar-residents-section) {
-    border-top-color: #4b5563;
-}
-
-.dark :deep(.residents-label) {
-    color: #9ca3af;
-}
-
-.dark :deep(.residents-list) {
-    color: #e5e7eb;
-}
-
-.dark :deep(.fc-day-today .fc-daygrid-day-number) {
-    background-color: #2563eb;
-    color: white;
+.dark :deep(::-webkit-scrollbar-thumb) {
+    background: #4b5563;
 }
 </style>

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -125,7 +125,8 @@ const dayCellContent = (info) => {
     
     console.log('dayCellContent returning html for', dateStr, ':', html.substring(0, 100))
     
-    return { html }
+    // FullCalendar v6では、stringまたは{ html: string }形式を返すことができます
+    return html
 }
 
 // 日付セルがマウントされた後にクリックイベントをバインド

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -21,6 +21,11 @@ const scheduleTypes = ref(props.scheduleTypes || [])
 const monthStats = ref(props.monthStats || { total: 0, by_type: {} })
 const currentDate = ref(props.currentDate || dayjs().format('YYYY-MM-DD'))
 
+// デバッグ: 初期データを確認
+console.log('Initial props:', props)
+console.log('Initial events:', events.value)
+console.log('Initial residents:', residents.value)
+
 // スケジュール作成フォームの表示状態
 const showScheduleForm = ref(false)
 const formInitialDate = ref(null)

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -184,7 +184,7 @@ const renderDayCellContent = (info) => {
 
     // 上部：スケジュールリスト（赤枠）
     const schedulesSection = document.createElement("div");
-    schedulesSection.className = "flex flex-col gap-1 p-1 overflow-y-auto flex-1 min-h-0 border-2 border-red-400 cursor-pointer hover:bg-red-50 dark:hover:bg-red-900/10 transition-colors";
+    schedulesSection.className = "flex flex-col gap-1 p-1 overflow-y-auto h-[40%] min-h-[40px] border-2 border-red-400 cursor-pointer hover:bg-red-50 dark:hover:bg-red-900/10 transition-colors";
 
     // 上部クリックイベント
     schedulesSection.addEventListener("click", (e) => {

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -398,9 +398,10 @@ const closeScheduleModal = () => {
     overflow-y: auto;
     min-height: 60px !important;
     max-height: none;
-    border-bottom: 2px solid #e5e7eb;
-    padding-bottom: 4px;
-    margin-bottom: 4px;
+    border-bottom: 3px solid #d1d5db !important;
+    padding-bottom: 6px;
+    margin-bottom: 6px;
+    box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.1);
 }
 
 :deep(.calendar-schedule-item) {
@@ -438,7 +439,9 @@ const closeScheduleModal = () => {
     flex-direction: column !important;
     min-height: 50px !important;
     max-height: none;
-    padding-top: 4px;
+    padding-top: 6px;
+    border-top: 1px solid rgba(0, 0, 0, 0.05);
+    margin-top: 2px;
 }
 
 :deep(.residents-label) {

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -109,20 +109,42 @@ const dayCellDidMount = (info) => {
     const dateStr = dayjs(info.date).format('YYYY-MM-DD')
     const dayData = eventsByDate.value[dateStr]
     
-    // 既存のコンテンツをクリア（日付番号以外）
-    const dayNumberEl = info.el.querySelector('.fc-daygrid-day-number')
-    if (!dayNumberEl) return
+    // FullCalendarのDOM構造:
+    // .fc-daygrid-day
+    //   .fc-daygrid-day-frame
+    //     .fc-daygrid-day-number (日付番号)
+    //     .fc-daygrid-day-events (デフォルトイベントコンテナ - 非表示にする)
+    //     .fc-daygrid-day-bg (背景)
     
-    // カスタムコンテンツコンテナを作成
-    let contentContainer = info.el.querySelector('.custom-day-content')
-    if (!contentContainer) {
-        contentContainer = document.createElement('div')
-        contentContainer.className = 'custom-day-content'
-        info.el.appendChild(contentContainer)
-    } else {
-        contentContainer.innerHTML = ''
+    // .fc-daygrid-day-frameを取得
+    const dayFrame = info.el.querySelector('.fc-daygrid-day-frame')
+    if (!dayFrame) return
+    
+    // デフォルトのイベント表示を非表示にする
+    const dayEvents = dayFrame.querySelector('.fc-daygrid-day-events')
+    if (dayEvents) {
+        dayEvents.style.display = 'none'
     }
     
+    // 既存のカスタムコンテンツを削除
+    const existingContent = dayFrame.querySelector('.custom-day-content')
+    if (existingContent) {
+        existingContent.remove()
+    }
+    
+    // カスタムコンテンツコンテナを作成
+    const contentContainer = document.createElement('div')
+    contentContainer.className = 'custom-day-content'
+    
+    // .fc-daygrid-day-numberの後に挿入
+    const dayNumberEl = dayFrame.querySelector('.fc-daygrid-day-number')
+    if (dayNumberEl && dayNumberEl.nextSibling) {
+        dayFrame.insertBefore(contentContainer, dayNumberEl.nextSibling)
+    } else {
+        dayFrame.appendChild(contentContainer)
+    }
+    
+    // データがない場合は空のコンテナだけ追加して終了
     if (!dayData || (dayData.schedules.length === 0 && dayData.residents.size === 0)) {
         return
     }

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -281,7 +281,21 @@ const calendarOptions = computed(() => ({
     headerToolbar: {
         left: "prev,next today",
         center: "title",
-        right: "",
+        right: "dayGridMonth,customWeek,customDay", // 標準のdayGridMonthとカスタムボタンを併用
+    },
+    customButtons: {
+        customWeek: {
+            text: '週',
+            click: () => {
+                router.get(route('calendar.week'), { date: currentDate.value });
+            }
+        },
+        customDay: {
+            text: '日',
+            click: () => {
+                router.get(route('calendar.day'), { date: currentDate.value });
+            }
+        }
     },
     buttonText: {
         today: "今日",

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -168,7 +168,10 @@ const dayCellDidMount = (info) => {
         })
     }
     
-    // 入浴予定者セクション
+    // スケジュールセクションを追加（常に追加）
+    contentContainer.appendChild(schedulesSection)
+    
+    // 入浴予定者セクション（下半分）
     if (dayData.residents.size > 0) {
         const residentsSection = document.createElement('div')
         residentsSection.className = 'calendar-residents-section'
@@ -188,10 +191,13 @@ const dayCellDidMount = (info) => {
         residentsSection.appendChild(labelDiv)
         residentsSection.appendChild(listDiv)
         
-        contentContainer.appendChild(schedulesSection)
         contentContainer.appendChild(residentsSection)
     } else {
-        contentContainer.appendChild(schedulesSection)
+        // 入浴予定者がいない場合でも、下半分のスペースを確保
+        const emptyResidentsSection = document.createElement('div')
+        emptyResidentsSection.className = 'calendar-residents-section'
+        emptyResidentsSection.style.minHeight = '50px'
+        contentContainer.appendChild(emptyResidentsSection)
     }
 }
 

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -83,26 +83,26 @@ const dayCellContent = (info) => {
     const dateStr = dayjs(info.date).format('YYYY-MM-DD')
     const dayData = eventsByDate.value[dateStr]
     
-    if (!dayData) {
-        return { html: '' }
-    }
-    
     // スケジュールセクション
-    const schedulesHtml = dayData.schedules.map(schedule => {
-        const time = dayjs(schedule.start).format('HH:mm')
-        const title = schedule.extendedProps?.schedule_type_name || schedule.title
-        const color = schedule.backgroundColor || '#3B82F6'
-        return `<div class="calendar-schedule-item" style="background-color: ${color};" data-event-id="${schedule.id}">
-            <span class="schedule-time">${time}</span>
-            <span class="schedule-title">${title}</span>
-        </div>`
-    }).join('')
+    const schedulesHtml = dayData && dayData.schedules.length > 0
+        ? dayData.schedules.map(schedule => {
+            const time = dayjs(schedule.start).format('HH:mm')
+            const title = schedule.extendedProps?.schedule_type_name || schedule.title
+            const color = schedule.backgroundColor || '#3B82F6'
+            return `<div class="calendar-schedule-item" style="background-color: ${color};" data-event-id="${schedule.id}">
+                <span class="schedule-time">${time}</span>
+                <span class="schedule-title">${title}</span>
+            </div>`
+        }).join('')
+        : ''
     
     // 入浴予定者セクション
-    const residentsList = Array.from(dayData.residents).map(residentId => {
-        const resident = residents.value.find(r => r.id === residentId)
-        return resident ? resident.name : ''
-    }).filter(Boolean)
+    const residentsList = dayData && dayData.residents.size > 0
+        ? Array.from(dayData.residents).map(residentId => {
+            const resident = residents.value.find(r => r.id === residentId)
+            return resident ? resident.name : ''
+        }).filter(Boolean)
+        : []
     
     const residentsHtml = residentsList.length > 0 
         ? `<div class="calendar-residents-section">

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -133,6 +133,7 @@ const dayCellContent = (info) => {
         </div>`
         : ''
     
+    // FullCalendar v6のdayCellContentは、{ html: string }形式を返す必要があります
     const html = `<div class="custom-day-cell">
         <div class="day-number">${info.dayNumberText}</div>
         <div class="day-content">
@@ -143,8 +144,8 @@ const dayCellContent = (info) => {
     
     console.log('dayCellContent returning html for', dateStr, ':', html.substring(0, 100))
     
-    // FullCalendar v6では、stringまたは{ html: string }形式を返すことができます
-    return html
+    // FullCalendar v6では、{ html: string }形式を返す必要があります
+    return { html }
 }
 
 // 日付セルがマウントされた後にクリックイベントをバインド

--- a/resources/js/Pages/Calendar/Week.vue
+++ b/resources/js/Pages/Calendar/Week.vue
@@ -1,0 +1,173 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { Head, usePage, router } from '@inertiajs/vue3'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+import FullCalendar from '@fullcalendar/vue3'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import timeGridPlugin from '@fullcalendar/timegrid'
+import interactionPlugin from '@fullcalendar/interaction'
+import dayjs from 'dayjs'
+import 'dayjs/locale/ja'
+import jaLocale from '@fullcalendar/core/locales/ja.js'
+import ScheduleForm from '@/Components/ScheduleForm.vue'
+import ScheduleModal from '@/Components/ScheduleModal.vue'
+
+dayjs.locale('ja')
+
+const { props } = usePage()
+
+const events = ref(props.events || [])
+const residents = ref(props.residents || [])
+const scheduleTypes = ref(props.scheduleTypes || [])
+const currentDate = ref(props.currentDate || dayjs().format('YYYY-MM-DD'))
+const startOfWeek = ref(props.startOfWeek || dayjs().startOf('week').add(1, 'day').format('YYYY-MM-DD')) // 月曜日始まり
+const endOfWeek = ref(props.endOfWeek || dayjs().endOf('week').add(1, 'day').format('YYYY-MM-DD'))
+
+// スケジュール作成フォームの表示状態
+const showScheduleForm = ref(false)
+const formInitialDate = ref(null)
+const formInitialResidentId = ref(null)
+
+// スケジュール詳細モーダルの表示状態
+const showScheduleModal = ref(false)
+const selectedSchedule = ref(null)
+
+// カレンダーの週変更時の処理
+const handleWeekChange = (info) => {
+    // 週が変更された場合、新しい週のデータを取得
+    const newDate = dayjs(info.start).format('YYYY-MM-DD')
+    const weekStart = dayjs(startOfWeek.value).format('YYYY-MM-DD')
+    const newWeekStart = dayjs(info.start).startOf('week').add(1, 'day').format('YYYY-MM-DD') // 月曜日始まり
+    
+    if (newWeekStart !== weekStart) {
+        // Inertiaでページを再読み込み
+        router.get(route('calendar.week'), { date: newDate }, {
+            preserveState: true,
+            preserveScroll: true,
+        })
+    }
+}
+
+// 日付クリック時の処理
+const handleDateClick = (info) => {
+    formInitialDate.value = dayjs(info.date).format('YYYY-MM-DD')
+    formInitialResidentId.value = null
+    showScheduleForm.value = true
+}
+
+// イベントクリック時の処理
+const handleEventClick = (info) => {
+    selectedSchedule.value = info.event
+    showScheduleModal.value = true
+}
+
+// FullCalendarの設定
+const calendarOptions = computed(() => ({
+    plugins: [dayGridPlugin, timeGridPlugin, interactionPlugin],
+    initialView: 'timeGridWeek',
+    locale: jaLocale,
+    headerToolbar: {
+        left: 'prev,next today',
+        center: 'title',
+        right: 'dayGridMonth,timeGridWeek,timeGridDay',
+    },
+    buttonText: {
+        today: '今日',
+        month: '月',
+        week: '週',
+        day: '日',
+    },
+    events: events.value,
+    eventDisplay: 'block',
+    height: 'auto',
+    editable: false, // 編集はモーダルから行う
+    selectable: false, // 範囲選択は無効 - 日付クリックで作成フォームを表示
+    dateClick: handleDateClick, // 日付クリック時の処理
+    eventClick: handleEventClick, // イベントクリック時の処理
+    slotMinTime: '06:00:00',
+    slotMaxTime: '22:00:00',
+    slotDuration: '00:30:00',
+    firstDay: 1, // 月曜日始まり
+}))
+
+// スケジュール作成成功時の処理
+const handleScheduleCreated = () => {
+    // カレンダーを再読み込み
+    router.reload({ only: ['events'] })
+}
+
+// フォームを閉じる
+const closeScheduleForm = () => {
+    showScheduleForm.value = false
+    formInitialDate.value = null
+    formInitialResidentId.value = null
+}
+
+// スケジュール更新成功時の処理
+const handleScheduleUpdated = () => {
+    // カレンダーを再読み込み
+    router.reload({ only: ['events'] })
+}
+
+// スケジュール削除成功時の処理
+const handleScheduleDeleted = () => {
+    // カレンダーを再読み込み
+    router.reload({ only: ['events'] })
+}
+
+// モーダルを閉じる
+const closeScheduleModal = () => {
+    showScheduleModal.value = false
+    selectedSchedule.value = null
+}
+</script>
+
+<template>
+    <AuthenticatedLayout>
+        <Head title="週間カレンダー" />
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900 dark:text-gray-100">
+                        <h1 class="text-2xl font-bold mb-6">週間カレンダー</h1>
+
+                        <!-- カレンダー表示 -->
+                        <div class="calendar-container">
+                            <FullCalendar :options="calendarOptions" @datesSet="handleWeekChange" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- スケジュール作成フォーム -->
+        <ScheduleForm
+            :show="showScheduleForm"
+            :initial-date="formInitialDate"
+            :initial-resident-id="formInitialResidentId"
+            :residents="residents"
+            :schedule-types="scheduleTypes"
+            @close="closeScheduleForm"
+            @success="handleScheduleCreated"
+        />
+
+        <!-- スケジュール詳細モーダル -->
+        <ScheduleModal
+            :show="showScheduleModal"
+            :schedule="selectedSchedule"
+            :residents="residents"
+            :schedule-types="scheduleTypes"
+            @close="closeScheduleModal"
+            @updated="handleScheduleUpdated"
+            @deleted="handleScheduleDeleted"
+        />
+    </AuthenticatedLayout>
+</template>
+
+<style>
+.calendar-container {
+    margin-top: 1rem;
+}
+</style>
+

--- a/resources/js/Pages/Calendar/Week.vue
+++ b/resources/js/Pages/Calendar/Week.vue
@@ -101,7 +101,21 @@ const calendarOptions = computed(() => ({
     headerToolbar: {
         left: 'prev,next today',
         center: 'title',
-        right: 'dayGridMonth,timeGridWeek,timeGridDay',
+        right: 'customMonth,timeGridWeek,customDay',
+    },
+    customButtons: {
+        customMonth: {
+            text: '月',
+            click: () => {
+                router.get(route('calendar.index'), { date: currentDate.value });
+            }
+        },
+        customDay: {
+            text: '日',
+            click: () => {
+                router.get(route('calendar.day'), { date: currentDate.value });
+            }
+        }
     },
     buttonText: {
         today: '今日',
@@ -120,6 +134,8 @@ const calendarOptions = computed(() => ({
     slotMaxTime: '22:00:00',
     slotDuration: '00:30:00',
     firstDay: 1, // 月曜日始まり
+    allDaySlot: false, // 終日スロットを非表示（必要に応じて有効化）
+    dayHeaderFormat: { weekday: 'short', month: 'numeric', day: 'numeric', omitCommas: true },
 }))
 
 // スケジュール作成成功時の処理
@@ -183,12 +199,20 @@ const closeScheduleModal = () => {
     <AuthenticatedLayout>
         <Head title="週間カレンダー" />
 
-        <div class="py-12">
-            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
-                    <div class="p-6 text-gray-900 dark:text-gray-100">
-                        <h1 class="text-2xl font-bold mb-6">週間カレンダー</h1>
+        <div class="py-8 bg-gray-50 dark:bg-gray-900 min-h-screen">
+            <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-8">
+                
+                <!-- ヘッダーエリア -->
+                <div class="flex flex-col md:flex-row justify-between items-center mb-8 gap-4">
+                    <div>
+                        <h1 class="text-3xl font-bold text-gray-800 dark:text-gray-100 tracking-tight">週間カレンダー</h1>
+                        <p class="text-gray-500 dark:text-gray-400 mt-1">週ごとのスケジュールを確認できます</p>
+                    </div>
+                </div>
 
+                <!-- カレンダーメインエリア -->
+                <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
+                    <div class="p-6">
                         <!-- カレンダー表示 -->
                         <div class="calendar-container">
                             <FullCalendar ref="calendarRef" :options="calendarOptions" @datesSet="handleWeekChange" />
@@ -222,9 +246,151 @@ const closeScheduleModal = () => {
     </AuthenticatedLayout>
 </template>
 
-<style>
+<style scoped>
+/* カレンダーコンテナ */
 .calendar-container {
-    margin-top: 1rem;
+    font-family: 'Inter', sans-serif;
+}
+
+/* FullCalendarの全体スタイル調整 */
+:deep(.fc) {
+    --fc-border-color: #f3f4f6;
+    --fc-today-bg-color: rgba(59, 130, 246, 0.05);
+    --fc-neutral-bg-color: #f9fafb;
+    --fc-page-bg-color: #ffffff;
+}
+
+.dark :deep(.fc) {
+    --fc-border-color: #374151;
+    --fc-neutral-bg-color: #1f2937;
+    --fc-page-bg-color: #1f2937;
+}
+
+/* ヘッダーツールバー */
+:deep(.fc-header-toolbar) {
+    margin-bottom: 1.5rem !important;
+}
+
+:deep(.fc-toolbar-title) {
+    font-size: 1.5rem !important;
+    font-weight: 700;
+    color: #1f2937;
+}
+
+.dark :deep(.fc-toolbar-title) {
+    color: #f3f4f6;
+}
+
+/* ボタンのカスタマイズ */
+:deep(.fc-button) {
+    background-color: white;
+    border: 1px solid #e5e7eb;
+    color: #374151;
+    font-weight: 500;
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    transition: all 0.2s;
+}
+
+:deep(.fc-button:hover) {
+    background-color: #f9fafb;
+    border-color: #d1d5db;
+    color: #111827;
+}
+
+:deep(.fc-button-primary:not(:disabled).fc-button-active),
+:deep(.fc-button-primary:not(:disabled):active) {
+    background-color: #3b82f6;
+    border-color: #3b82f6;
+    color: white;
+}
+
+.dark :deep(.fc-button) {
+    background-color: #374151;
+    border-color: #4b5563;
+    color: #e5e7eb;
+}
+
+.dark :deep(.fc-button:hover) {
+    background-color: #4b5563;
+}
+
+/* 曜日ヘッダー */
+:deep(.fc-col-header-cell) {
+    padding: 0.75rem 0;
+    background-color: #f9fafb;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+:deep(.fc-col-header-cell-cushion) {
+    color: #6b7280;
+    font-weight: 600;
+    text-decoration: none;
+    font-size: 0.875rem;
+}
+
+.dark :deep(.fc-col-header-cell) {
+    background-color: #1f2937;
+    border-bottom-color: #374151;
+}
+
+.dark :deep(.fc-col-header-cell-cushion) {
+    color: #9ca3af;
+}
+
+/* タイムグリッドのスロット */
+:deep(.fc-timegrid-slot) {
+    height: 3rem; /* スロットの高さを少し広げる */
+}
+
+:deep(.fc-timegrid-slot-label) {
+    font-size: 0.75rem;
+    color: #6b7280;
+    font-weight: 500;
+}
+
+/* イベントスタイル（TimeGrid用） */
+:deep(.fc-timegrid-event) {
+    border-radius: 6px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    border: none;
+    padding: 2px;
+    transition: transform 0.1s;
+}
+
+:deep(.fc-timegrid-event:hover) {
+    transform: scale(1.02);
+    z-index: 5;
+}
+
+:deep(.fc-event-main) {
+    padding: 2px 4px;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+/* スクロールバーのカスタマイズ */
+:deep(::-webkit-scrollbar) {
+    width: 6px;
+    height: 6px;
+}
+
+:deep(::-webkit-scrollbar-track) {
+    background: transparent;
+}
+
+:deep(::-webkit-scrollbar-thumb) {
+    background: #d1d5db;
+    border-radius: 3px;
+}
+
+:deep(::-webkit-scrollbar-thumb:hover) {
+    background: #9ca3af;
+}
+
+.dark :deep(::-webkit-scrollbar-thumb) {
+    background: #4b5563;
 }
 </style>
 

--- a/resources/js/Pages/Calendar/Week.vue
+++ b/resources/js/Pages/Calendar/Week.vue
@@ -69,6 +69,16 @@ const handleWeekChange = (info) => {
 
 // 日付クリック時の処理
 const handleDateClick = (info) => {
+    // イベントがクリックされた場合は何もしない（eventClickで処理される）
+    const clickedElement = info.jsEvent?.target;
+    if (clickedElement) {
+        // イベント要素がクリックされた場合は無視
+        const eventElement = clickedElement.closest('.fc-event');
+        if (eventElement) {
+            return; // イベントクリックで処理されるため、dateClickは無視
+        }
+    }
+    
     formInitialDate.value = dayjs(info.date).format('YYYY-MM-DD')
     formInitialResidentId.value = null
     showScheduleForm.value = true
@@ -76,6 +86,9 @@ const handleDateClick = (info) => {
 
 // イベントクリック時の処理
 const handleEventClick = (info) => {
+    // スケジュール作成フォームを閉じる（誤って開かないように）
+    showScheduleForm.value = false
+    
     selectedSchedule.value = info.event
     showScheduleModal.value = true
 }
@@ -143,6 +156,9 @@ const handleScheduleUpdated = () => {
 const handleScheduleDeleted = (deletedScheduleId) => {
     console.log('handleScheduleDeleted called (Week)', deletedScheduleId);
     
+    // まずモーダルを閉じる（確実に閉じるため）
+    closeScheduleModal();
+    
     if (deletedScheduleId) {
         // 削除されたスケジュールをeventsから直接削除
         events.value = events.value.filter(event => event.id !== deletedScheduleId);
@@ -154,9 +170,6 @@ const handleScheduleDeleted = (deletedScheduleId) => {
             calendarApi.refetchEvents();
         }
     }
-    
-    // モーダルを閉じる
-    closeScheduleModal();
 }
 
 // モーダルを閉じる

--- a/resources/js/Pages/Calendar/Week.vue
+++ b/resources/js/Pages/Calendar/Week.vue
@@ -140,9 +140,23 @@ const handleScheduleUpdated = () => {
 }
 
 // スケジュール削除成功時の処理
-const handleScheduleDeleted = () => {
-    // カレンダーを再読み込み
-    router.reload({ only: ['events'] })
+const handleScheduleDeleted = (deletedScheduleId) => {
+    console.log('handleScheduleDeleted called (Week)', deletedScheduleId);
+    
+    if (deletedScheduleId) {
+        // 削除されたスケジュールをeventsから直接削除
+        events.value = events.value.filter(event => event.id !== deletedScheduleId);
+        console.log('Removed deleted event from events.value:', events.value.length);
+        
+        // FullCalendarのイベントを更新
+        if (calendarRef.value) {
+            const calendarApi = calendarRef.value.getApi();
+            calendarApi.refetchEvents();
+        }
+    }
+    
+    // モーダルを閉じる
+    closeScheduleModal();
 }
 
 // モーダルを閉じる

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -364,7 +364,7 @@ const openModal = (imageSrc) => {
             />
 
             <!-- メインコンテンツエリア -->
-            <div class="flex-1 p-4">
+            <div class="flex-1 p-4 forum-main-content">
                 <!-- サイドバーのトグルボタンと検索フォーム -->
                 <div class="flex items-center mb-4 relative">
                     <h1
@@ -679,7 +679,7 @@ const openModal = (imageSrc) => {
     </AuthenticatedLayout>
 </template>
 
-<style>
+<style scoped>
 /* サイドバーが表示されている場合、ボディのスクロールを禁止 */
 body.no-scroll {
     overflow: hidden;
@@ -719,7 +719,7 @@ body.no-scroll {
         width: 220px; /* iPadサイズではサイドバーを狭くする */
     }
 
-    .flex-1 {
+    .forum-main-content {
         margin-left: 220px; /* サイドバーの幅分余白を調整 */
     }
 }
@@ -730,14 +730,14 @@ body.no-scroll {
         width: 250px; /* 通常のサイドバー幅 */
     }
 
-    .flex-1 {
+    .forum-main-content {
         margin-left: 250px; /* 通常の余白 */
     }
 }
 
 /* 全画面表示専用（デスクトップサイズ以上） */
 @media (min-width: 1366px) {
-    .flex-1 {
+    .forum-main-content {
         margin-left: 280px; /* サイドバー幅より広い余白を設定 */
         margin-right: 280px; /* サイドバー幅より広い余白を設定 */
     }

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -49,6 +49,8 @@ Route::middleware(['auth'])->group(function () {
 
     // カレンダー
     Route::get('/calendar', [CalendarController::class, 'index'])->name('calendar.index');
+    Route::get('/calendar/week', [CalendarController::class, 'week'])->name('calendar.week');
+    Route::get('/calendar/day/{date?}', [CalendarController::class, 'day'])->name('calendar.day');
 
     // スケジュール
     Route::get('/calendar/schedules', [ScheduleController::class, 'index'])->name('calendar.schedules.index');


### PR DESCRIPTION
# Pull Request: カレンダー日次ビューのUI改善（スケジュールと入浴予定の分離）

## 目的
カレンダーの日次ビューにおいて、通常のスケジュールと入浴予定（居住者スケジュール）が混在しており、視認性が低かったため、これらを分離し、モダンなピル型デザイン（Pill Design）を適用して視認性と操作性を向上させる。

## 達成条件
- 日次ビュー内で、通常のスケジュールと入浴予定が別の領域（論理的なグループ）として扱われること。
- 入浴予定（`resident_id`を持つイベント）が青系のピル型デザインで表示されること。
- 通常スケジュールが既存のデザイン（または適切なピル型）で表示されること。
- 各スケジュールクリック時に詳細が表示されること（既存機能の維持）。

## 実装の概要
- `resources/js/Pages/Calendar/Index.vue` の修正
    - `eventsByDate` Computedプロパティのロジックを変更し、`regularSchedules` と `bathSchedules` に分割して集計するように変更。
    - `renderDayCellContent` 内での描画ロジックを更新。
        - 従来の `residents` (Set) によるバッジ表示を廃止し、`bathSchedules` 配列をループしてピル型要素を作成・追加。
        - 入浴予定のスタイルを青系 (`#3B82F6`) に統一し、borderLeft でステータスを表現。
        - クリックイベントを各要素にバインド。

## 対処したバグ
- 特になし（機能改善）

## 必要なかった実装
- 特になし

## レビューしてほしいところ
- 入浴予定の表示スタイル（色味やサイズ感）。
- モバイル表示時のレイアウト崩れがないか。

## 不安に思っていること
- 特になし

## 保留していること
- 入浴スケジュールのタイトルとして現在はスケジュール名を表示しているが、居住者名 (`resident.name`) を表示する仕様への変更（コードコメントに残している）。
