### PR TITLE
トップページ（communicare.jp）が表示されない不具合の修正

### DIFF
--- a/app/Http/Middleware/SetSessionDomain.php
+++ b/app/Http/Middleware/SetSessionDomain.php
@@ -40,8 +40,8 @@ class SetSessionDomain
      */
     protected function resolveDomain(string $host): ?string
     {
-        // communi-care.jp ドメインおよびサブドメインを許可
-        if (preg_match('/^.+\.communi-care\.jp$/', $host)) {
+        // communi-care.jp, communicare.jp ドメインおよびサブドメインを許可
+        if (preg_match('/^.+\.(communi-care|communicare)\.jp$/', $host)) {
             return $host;
         }
 

--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -20,6 +20,7 @@ return [
         '127.0.0.1',
         'localhost',
         'communi-care.jp',//本番のセントラルドメイン
+        'communicare.jp',
     ],
 
     /**


### PR DESCRIPTION
### 目的

`communicare.jp` にアクセスした際、本来表示されるべき `Welcome.vue` ではなく、テナント用の `TenantHome.vue` が表示されてしまう問題を解消すること。

### 達成条件

- 本番環境（`communicare.jp`）でトップページ（`Welcome.vue`）が正しく表示されること。
- `communicare.jp` およびそのサブドメインでセッションが正常に動作すること。

### 実装の概要

1. **`config/tenancy.php` の修正**:
   - `central_domains` に `communicare.jp` を追加し、テナント識別ロジックから除外されるようにしました。

2. **`app/Http/Middleware/SetSessionDomain.php` の修正**:
   - セッションドメイン解決ロジックを更新し、`communicare.jp` 配下でも正しく動作するように正規表現を調整しました。

### 対処したバグ

- ルートドメイン（`communicare.jp`）がテナントとして誤認される不具合。

### 必要なかった実装

- 特になし。

### レビューしてほしいところ

- `SetSessionDomain.php` の正規表現が意図通りか（`communi-care.jp` と `communicare.jp` 両対応）。
- `config/tenancy.php` への追加が適切か。

### 不安に思っていること

- 特になし。

### 保留していること

- 特になし。
