### PR TITLE
fix: www.communi-care.jp でトップページが表示されない不具合の修正

### DIFF
--- a/app/Http/Middleware/SetSessionDomain.php
+++ b/app/Http/Middleware/SetSessionDomain.php
@@ -40,8 +40,8 @@ class SetSessionDomain
      */
     protected function resolveDomain(string $host): ?string
     {
-        // communi-care.jp ドメインおよびサブドメインを許可
-        if (preg_match('/^.+\.communi-care\.jp$/', $host)) {
+        // communi-care.jp ドメイン（www含む）およびサブドメインを許可
+        if (preg_match('/(^|.+\.)communi-care\.jp$/', $host)) {
             return $host;
         }
 

--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -20,6 +20,7 @@ return [
         '127.0.0.1',
         'localhost',
         'communi-care.jp',//本番のセントラルドメイン
+        'www.communi-care.jp',
     ],
 
     /**


### PR DESCRIPTION
### 目的

`www.communi-care.jp` にアクセスした際、本来表示されるべき `Welcome.vue` ではなく、テナント用の `TenantHome.vue` が表示されてしまう問題を解消すること。また、ネイキッドドメイン（`communi-care.jp`）でのセッション共有が正しく行われない可能性がある問題を修正すること。

### 達成条件

- 本番環境（`www.communi-care.jp`）でトップページ（`Welcome.vue`）が正しく表示されること。
- `communi-care.jp` および `www.communi-care.jp` でセッションが正常に動作すること。

### 実装の概要

1. **`config/tenancy.php` の修正**:
   - `central_domains` に `www.communi-care.jp` を追加し、テナント識別ロジックから除外されるようにしました。テナント識別ロジックは完全一致を要求するため、`www` の追加が必須でした。

2. **`app/Http/Middleware/SetSessionDomain.php` の修正**:
   - セッションドメイン解決ロジックを更新し、`communi-care.jp`（ネイキッドドメイン）およびそのサブドメイン（`www`含む）で正しくマッチするように正規表現を `/(^|.+\.)communi-care\.jp$/` に修正しました。

### 対処したバグ

- `www.communi-care.jp` がテナントとして誤認される不具合。
- セッションドメインの正規表現がネイキッドドメインを許容していなかった可能性の修正。

### 必要なかった実装

- 単なる `communicare.jp` ドメインの追加（本番ドメインは `communi-care.jp` であったため）。

### レビューしてほしいところ

- `SetSessionDomain.php` の正規表現が意図通りか。
- `config/tenancy.php` への追加が適切か。

### 不安に思っていること

- 特になし。

### 保留していること

- 特になし。
