### PR TITLE
fix: resolve stancl/tenancy PHP 8.3 warnings and Vite 504 error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require-dev": {
         "askdkc/breezejp": "^2.3",
         "barryvdh/laravel-debugbar": "^3.13",
+        "cweagans/composer-patches": "^2.0",
         "fakerphp/faker": "^1.23",
         "laravel/breeze": "^2.1",
         "laravel/pint": "^1.13",
@@ -56,6 +57,11 @@
         ]
     },
     "extra": {
+        "patches": {
+            "stancl/tenancy": {
+                "Fix PHP 8.3 static trait property access warnings": "patches/stancl-tenancy-fix-php83.patch"
+            }
+        },
         "laravel": {
             "dont-discover": []
         }
@@ -66,7 +72,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true,
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "cweagans/composer-patches": true
         }
     },
     "minimum-stability": "stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae400e8b0735693c72a2946a97268a30",
+    "content-hash": "3223f9f7ffd88f0cf48a01051952d634",
     "packages": [
         {
             "name": "brick/math",
@@ -6597,6 +6597,129 @@
             "time": "2025-03-05T08:29:11+00:00"
         },
         {
+            "name": "cweagans/composer-configurable-plugin",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-configurable-plugin.git",
+                "reference": "15433906511a108a1806710e988629fd24b89974"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-configurable-plugin/zipball/15433906511a108a1806710e988629fd24b89974",
+                "reference": "15433906511a108a1806710e988629fd24b89974",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "require-dev": {
+                "codeception/codeception": "~4.0",
+                "codeception/module-asserts": "^2.0",
+                "composer/composer": "~2.0",
+                "php-coveralls/php-coveralls": "~2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.0.0",
+                "phpro/grumphp": "^1.8.0",
+                "sebastian/phpcpd": "^6.0",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a lightweight configuration system for Composer plugins.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-configurable-plugin/issues",
+                "source": "https://github.com/cweagans/composer-configurable-plugin/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/cweagans",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-12T04:58:58+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "bfa6018a5f864653d9ed899b902ea72f858a2cf7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/bfa6018a5f864653d9ed899b902ea72f858a2cf7",
+                "reference": "bfa6018a5f864653d9ed899b902ea72f858a2cf7",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "cweagans/composer-configurable-plugin": "^2.0",
+                "ext-json": "*",
+                "php": ">=8.0.0"
+            },
+            "require-dev": {
+                "codeception/codeception": "~4.0",
+                "codeception/module-asserts": "^2.0",
+                "codeception/module-cli": "^2.0",
+                "codeception/module-filesystem": "^2.0",
+                "composer/composer": "~2.0",
+                "php-coveralls/php-coveralls": "~2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.0.0",
+                "phpro/grumphp": "^1.8.0",
+                "sebastian/phpcpd": "^6.0",
+                "squizlabs/php_codesniffer": "^4.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "_": "The following two lines ensure that composer-patches is loaded as early as possible.",
+                "class": "cweagans\\Composer\\Plugin\\Patches",
+                "plugin-modifies-downloads": true,
+                "plugin-modifies-install-path": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/cweagans",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-10-30T23:44:22+00:00"
+        },
+        {
             "name": "doctrine/deprecations",
             "version": "1.1.5",
             "source": {
@@ -9871,12 +9994,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "axios": "^1.6.4",
                 "laravel-vite-plugin": "^1.0",
                 "postcss": "^8.4.31",
+                "rimraf": "^6.1.2",
                 "tailwindcss": "^3.2.1",
                 "vite": "^5.0",
                 "vue": "^3.4.0"
@@ -571,6 +572,29 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/kazupon"
+            }
+        },
+        "node_modules/@isaacs/balanced-match": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@isaacs/brace-expansion": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@isaacs/balanced-match": "^4.0.1"
+            },
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/@isaacs/cliui": {
@@ -2136,10 +2160,11 @@
             }
         },
         "node_modules/package-json-from-dist": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
-            "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
-            "dev": true
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0"
         },
         "node_modules/path-key": {
             "version": "3.1.1",
@@ -2459,6 +2484,87 @@
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/rimraf": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+            "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "glob": "^13.0.0",
+                "package-json-from-dist": "^1.0.1"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rimraf/node_modules/glob": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.1.1",
+                "minipass": "^7.1.2",
+                "path-scurry": "^2.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rimraf/node_modules/lru-cache": {
+            "version": "11.2.4",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+            "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/rimraf/node_modules/minimatch": {
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/brace-expansion": "^5.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rimraf/node_modules/path-scurry": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "scripts": {
         "dev": "vite",
         "build": "vite build",
-        "clean": "rm -rf node_modules/.vite"
+        "clean": "rimraf node_modules/.vite"
     },
     "devDependencies": {
         "@inertiajs/vue3": "^2.0.4",
@@ -14,6 +14,7 @@
         "axios": "^1.6.4",
         "laravel-vite-plugin": "^1.0",
         "postcss": "^8.4.31",
+        "rimraf": "^6.1.2",
         "tailwindcss": "^3.2.1",
         "vite": "^5.0",
         "vue": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "vite build"
+        "build": "vite build",
+        "clean": "rm -rf node_modules/.vite"
     },
     "devDependencies": {
         "@inertiajs/vue3": "^2.0.4",

--- a/patches.lock.json
+++ b/patches.lock.json
@@ -1,0 +1,17 @@
+{
+    "_hash": "004effe311b619c397939d8188f1a76a782e057453849b604cf0e349a56f1555",
+    "patches": {
+        "stancl/tenancy": [
+            {
+                "package": "stancl/tenancy",
+                "description": "Fix PHP 8.3 static trait property access warnings",
+                "url": "patches/stancl-tenancy-fix-php83.patch",
+                "sha256": "44d403e683c9317dca0a32c8a06fa2ba1a54d60048c808c5d657531472cf0695",
+                "depth": 1,
+                "extra": {
+                    "provenance": "root"
+                }
+            }
+        ]
+    }
+}

--- a/patches/stancl-tenancy-fix-php83.patch
+++ b/patches/stancl-tenancy-fix-php83.patch
@@ -16,7 +16,7 @@
      public function tenant()
      {
 -        return $this->belongsTo(config('tenancy.tenant_model'), BelongsToTenant::$tenantIdColumn);
-+        return $this->belongsTo(config('tenancy.tenant_model'), $model::$tenantIdColumn);
++        return $this->belongsTo(config('tenancy.tenant_model'), static::$tenantIdColumn);
      }
  
      public static function bootBelongsToTenant()

--- a/patches/stancl-tenancy-fix-php83.patch
+++ b/patches/stancl-tenancy-fix-php83.patch
@@ -1,0 +1,50 @@
+--- a/src/Database/TenantScope.php	2025-12-25 17:34:38
++++ b/src/Database/TenantScope.php	2025-12-25 17:34:41
+@@ -17,7 +17,7 @@
+             return;
+         }
+ 
+-        $builder->where($model->qualifyColumn(BelongsToTenant::$tenantIdColumn), tenant()->getTenantKey());
++        $builder->where($model->qualifyColumn($model::$tenantIdColumn), tenant()->getTenantKey());
+     }
+ 
+     public function extend(Builder $builder)
+--- a/src/Database/Concerns/BelongsToTenant.php	2025-12-25 17:34:38
++++ b/src/Database/Concerns/BelongsToTenant.php	2025-12-25 17:37:10
+@@ -16,7 +16,7 @@
+ 
+     public function tenant()
+     {
+-        return $this->belongsTo(config('tenancy.tenant_model'), BelongsToTenant::$tenantIdColumn);
++        return $this->belongsTo(config('tenancy.tenant_model'), $model::$tenantIdColumn);
+     }
+ 
+     public static function bootBelongsToTenant()
+@@ -24,9 +24,9 @@
+         static::addGlobalScope(new TenantScope);
+ 
+         static::creating(function ($model) {
+-            if (! $model->getAttribute(BelongsToTenant::$tenantIdColumn) && ! $model->relationLoaded('tenant')) {
++            if (! $model->getAttribute($model::$tenantIdColumn) && ! $model->relationLoaded('tenant')) {
+                 if (tenancy()->initialized) {
+-                    $model->setAttribute(BelongsToTenant::$tenantIdColumn, tenant()->getTenantKey());
++                    $model->setAttribute($model::$tenantIdColumn, tenant()->getTenantKey());
+                     $model->setRelation('tenant', tenant());
+                 }
+             }
+--- a/src/Database/Concerns/HasScopedValidationRules.php	2025-12-25 17:34:38
++++ b/src/Database/Concerns/HasScopedValidationRules.php	2025-12-25 17:34:44
+@@ -11,11 +11,11 @@
+ {
+     public function unique($table, $column = 'NULL')
+     {
+-        return (new Unique($table, $column))->where(BelongsToTenant::$tenantIdColumn, $this->getTenantKey());
++        return (new Unique($table, $column))->where(static::$tenantIdColumn, $this->getTenantKey());
+     }
+ 
+     public function exists($table, $column = 'NULL')
+     {
+-        return (new Exists($table, $column))->where(BelongsToTenant::$tenantIdColumn, $this->getTenantKey());
++        return (new Exists($table, $column))->where(static::$tenantIdColumn, $this->getTenantKey());
+     }
+ }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,10 +1,10 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 /* FullCalendar v6 CSS - CDNから読み込む */
 @import url('https://cdn.jsdelivr.net/npm/@fullcalendar/core@6.1.19/index.global.min.css');
 @import url('https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@6.1.19/index.global.min.css');
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 img {
     max-width: 100%; /* 親要素の幅に合わせる */


### PR DESCRIPTION
### 目的

stancl/tenancy パッケージ使用時に発生するPHP 8.3以降のdeprecated warning（static trait property access）を解消し、あわせて開発環境で発生していたViteの504エラーとCSSビルドエラーを修正する。

### 達成条件

- ログから 'Accessing static trait property' 警告が消滅していること。
- 'npm run dev' で開発サーバーが正常に起動し、ブラウザで504エラーやCSSエラーが発生しないこと。

### 実装の概要

- **Tenancy警告の修正**: 'cweagans/composer-patches' を導入し、'stancl/tenancy' にパッチ ('patches/stancl-tenancy-fix-php83.patch') を適用してdeprecatedな構文を修正。
- **Vite最適化エラーの修正**: 'package.json' に Viteキャッシュクリア用の 'clean' スクリプト ('rm -rf node_modules/.vite') を追加。
- **CSSエラーの修正**: 'resources/css/app.css' の '@import' 文をファイルの先頭に移動。

### 対処したバグ

- 'stancl/tenancy' の 'BelongsToTenant::$tenantIdColumn' へのstaticアクセス警告。
- Viteの依存関係キャッシュ不整合による504エラー。
- CSSビルド時の '@import must precede all other statements' エラー。

### 必要なかった実装

- なし。

### レビューしてほしいところ

- パッチファイルの内容（意図しない変更が含まれていないか）。
- 'composer.json' のパッチ適用設定。

### 不安に思っていること

- 'stancl/tenancy' の将来のバージョンアップでパッチが競合する可能性がある（v4系へ移行すれば不要になる見込み）。

### 保留していること

- 特になし。