### PR TITLE
本番環境との互換性を保つためのクエリパラメータサポート

### DIFF
--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -14,9 +14,9 @@ const guestDomain =
     import.meta.env.VITE_GUEST_TENANT_URL || "http://guestdemo.localhost";
 const isGuestUrl = ref(currentUrl.includes(`${guestDomain}/login`));
 
+const searchParams = new URLSearchParams(window.location.search);
 const isAdminMode = ref(
-    new URLSearchParams(window.location.search).has("admin") ||
-        new URLSearchParams(window.location.search).has("/admin")
+    searchParams.has("admin") || searchParams.has("/admin")
 );
 
 // フォームデータにusername_idを使用

--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -15,7 +15,8 @@ const guestDomain =
 const isGuestUrl = ref(currentUrl.includes(`${guestDomain}/login`));
 
 const isAdminMode = ref(
-    new URLSearchParams(window.location.search).has("admin")
+    new URLSearchParams(window.location.search).has("admin") ||
+        new URLSearchParams(window.location.search).has("/admin")
 );
 
 // フォームデータにusername_idを使用


### PR DESCRIPTION
### 目的

本番環境（`guestdemo.communi-care.jp`）において、管理者ログインURL `.../login?/admin` にアクセスした際、`?admin` ではなく `/admin` パラメータとして認識され、管理者モードが有効にならない（「セッションが切れました」と表示される）問題を修正する。

### 達成条件

- `?/admin` （キーが `/admin`）の形式でも管理者モードとして認識され、ログインフォームが表示されること。
- `?admin` （キーが `admin`）の形式も引き続き動作すること。

### 実装の概要

- `resources/js/Pages/Auth/Login.vue` の `isAdminMode` 判定ロジックに、`new URLSearchParams(...).has("/admin")` を追加。

### 対処したバグ

- 本番環境での管理者ログイン時に「セッションが切れました」と表示されるバグ。

### 必要なかった実装

- なし

### レビューしてほしいところ

- `URLSearchParams` の判定ロジックが、意図通り `?/admin` をカバーできているか。

### 不安に思っていること

- 特になし

### 保留していること

- 特になし